### PR TITLE
Make it easier to create other visualizations

### DIFF
--- a/viz_scripts/mode_purpose_share.ipynb
+++ b/viz_scripts/mode_purpose_share.ipynb
@@ -5,7 +5,15 @@
    "id": "prerequisite-norwegian",
    "metadata": {},
    "source": [
-    "This is a file that blah blah blah"
+    "## Sample code to generate static graphs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "colored-frost",
+   "metadata": {},
+   "source": [
+    "These are the input parameters for the notebook. They will be automatically changed when the scripts to generate monthly statistics are run. You can modify them manually to generate multiple plots locally as well. "
    ]
   },
   {
@@ -27,9 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import emission.storage.timeseries.abstract_timeseries as esta\n",
-    "import emission.storage.timeseries.tcquery as esttc\n",
-    "import emission.core.wrapper.localdate as ecwl"
+    "import scaffolding"
    ]
   },
   {
@@ -45,75 +51,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fundamental-compact",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import emission.core.get_database as edb"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "nuclear-converter",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "participant_uuid_obj = list(edb.get_profile_db().find({\"install_group\": \"participant\"}, {\"user_id\": 1, \"_id\": 0}))\n",
-    "participant_uuid_str = [u[\"user_id\"] for u in participant_uuid_obj]\n",
-    "participant_uuid_str"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "unauthorized-miami",
    "metadata": {},
    "outputs": [],
    "source": [
-    "query_ld = ecwl.LocalDate({\"year\": year, \"month\": month})\n",
-    "tq = esttc.TimeComponentQuery(\"data.start_local_dt\", query_ld, query_ld)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "opened-lithuania",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "agg = esta.TimeSeries.get_aggregate_time_series()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "universal-tonight",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "all_ct = agg.get_data_df(\"analysis/confirmed_trip\", tq)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "current-primary",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "all_ct.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "alike-canberra",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "participant_ct_df = all_ct[all_ct.user_id.isin(participant_uuid_str)]\n",
-    "len(participant_ct_df)"
+    "tq = scaffolding.get_time_query(year, month)"
    ]
   },
   {
@@ -123,8 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "confirmed_ct = participant_ct_df[participant_ct_df.user_input != {}]\n",
-    "confirmed_ct.head()"
+    "participant_ct_df = scaffolding.load_all_participant_trips(program, tq)"
    ]
   },
   {
@@ -134,8 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "confirm_only = pd.DataFrame(confirmed_ct.user_input.to_list())\n",
-    "confirm_only.head()"
+    "labeled_ct = scaffolding.filter_labeled_trips(participant_ct_df)"
    ]
   },
   {
@@ -145,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "confirm_only.mode_confirm.head()"
+    "expanded_ct = scaffolding.expand_userinputs(labeled_ct)"
    ]
   },
   {
@@ -155,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mode_confirm_vals = confirm_only.mode_confirm.value_counts()\n",
+    "mode_confirm_vals = expanded_ct.mode_confirm.value_counts()\n",
     "mode_confirm_vals"
    ]
   },
@@ -220,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "confirmed_ct.user_id.unique()"
+    "expanded_ct.user_id.unique()"
    ]
   },
   {
@@ -231,7 +171,7 @@
    "outputs": [],
    "source": [
     "# check quality\n",
-    "cq = (len(confirmed_ct), len(confirmed_ct.user_id.unique()), len(participant_ct_df), len(participant_ct_df.user_id.unique()), (len(confirmed_ct) * 100) / len(participant_ct_df), )\n",
+    "cq = (len(expanded_ct), len(expanded_ct.user_id.unique()), len(participant_ct_df), len(participant_ct_df.user_id.unique()), (len(expanded_ct) * 100) / len(participant_ct_df), )\n",
     "quality_text = \"Based on %s confirmed trips from %d users\\nof %s total trips from %d users (%.2f%%)\" % cq"
    ]
   },

--- a/viz_scripts/scaffolding.py
+++ b/viz_scripts/scaffolding.py
@@ -1,0 +1,64 @@
+import pandas as pd
+
+import emission.storage.timeseries.abstract_timeseries as esta
+import emission.storage.timeseries.tcquery as esttc
+import emission.core.wrapper.localdate as ecwl
+
+# Module for pretty-printing outputs (e.g. head) to help users
+# understand what is going on
+# However, this means that this module can only be used in an ipython notebook
+import IPython.display as disp
+
+import emission.core.get_database as edb
+
+def get_time_query(year, month):
+    query_ld = ecwl.LocalDate({"year": year, "month": month})
+    tq = esttc.TimeComponentQuery("data.start_local_dt", query_ld, query_ld)
+    return tq
+
+def get_participant_uuids(program):
+    """
+        Get the list of participant UUIDs for the specified program.
+        Note that the "program" parameter is currently a NOP but will be enabled
+        once we have other programs start
+    """
+    participant_uuid_obj = list(edb.get_profile_db().find({"install_group": "participant"}, {"user_id": 1, "_id": 0}))
+    participant_uuid_str = [u["user_id"] for u in participant_uuid_obj]
+    disp.display(participant_uuid_str)
+    return participant_uuid_str
+
+def load_all_confirmed_trips(tq):
+    agg = esta.TimeSeries.get_aggregate_time_series()
+    all_ct = agg.get_data_df("analysis/confirmed_trip", tq)
+    print("Loaded all confirmed trips of length %s" % len(all_ct))
+    disp.display(all_ct.head())
+    return all_ct
+
+def load_all_participant_trips(program, tq):
+    participant_list = get_participant_uuids(program)
+    all_ct = load_all_confirmed_trips(tq)
+    participant_ct_df = all_ct[all_ct.user_id.isin(participant_list)]
+    print("After filtering, found %s participant trips " % len(participant_ct_df))
+    disp.display(participant_ct_df.head())
+    return participant_ct_df
+
+def filter_labeled_trips(mixed_trip_df):
+    labeled_ct = mixed_trip_df[mixed_trip_df.user_input != {}]
+    print("After filtering, found %s labeled trips" % len(labeled_ct))
+    disp.display(labeled_ct.head())
+    return labeled_ct
+
+def expand_userinputs(labeled_ct):
+    label_only = pd.DataFrame(labeled_ct.user_input.to_list(), index=labeled_ct.index)
+    disp.display(label_only.head())
+    expanded_ct = pd.concat([labeled_ct, label_only], axis=1)
+    assert len(expanded_ct) == len(labeled_ct), \
+        ("Mismatch after expanding labels, expanded_ct.rows = %s != labeled_ct.rows" %
+            (len(expanded_ct), len(labeled_ct)))
+    print("After expanding, columns went from %s -> %s" %
+        (len(labeled_ct.columns), len(expanded_ct.columns)))
+    assert len(expanded_ct.columns) == len(labeled_ct.columns) + 3, \
+        ("Mismatch after expanding labels, expanded_ct.columns = %s != labeled_ct.rows" %
+            (len(expanded_ct.columns), len(labeled_ct.columns)))
+    disp.display(expanded_ct.head())
+    return expanded_ct


### PR DESCRIPTION
- Pull the code to read, filter and expand the confirmed_trips into a separate module
- Modify the existing notebook to call the module; this leads to a very simplified implementation
- Check in both the notebook and the module

Should we move other functions (maybe the `quality_text` generation) into the module?

This fixes https://github.com/e-mission/em-public-dashboard/issues/6