### PR TITLE
Support different aggregations (all years, all months, all pilots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ instead of the *8080* in the logs, since we remap it as part of the docker-compo
 
 #### Test the notebook install
 
-Copy the URL that looks like this in the logs
-```
-http://<container_id>:8888/?token=<token>
-```
-replace `<container_id>` with localhost and `8888` with `47962` (`.ipynb` in numbers)
-
-Load the resulting URL in your browser
+Use the notebook URL from the console but change `8888` to `47962`
 
 ```
-http://localhost:47962/?token=<token>
+http://127.0.0.1:8888/?token=<token>
+```
+
+becomes
+
+```
+http://127.0.0.1:47962/?token=<token>
 ```
 
 #### Load some data

--- a/viz_scripts/mode_purpose_share.ipynb
+++ b/viz_scripts/mode_purpose_share.ipynb
@@ -172,9 +172,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# check quality\n",
-    "cq = (len(expanded_ct), len(expanded_ct.user_id.unique()), len(participant_ct_df), len(participant_ct_df.user_id.unique()), (len(expanded_ct) * 100) / len(participant_ct_df), )\n",
-    "quality_text = \"Based on %s confirmed trips from %d users\\nof %s total trips from %d users (%.2f%%)\" % cq"
+    "quality_text = scaffolding.get_quality_text(participant_ct_df, expanded_ct)"
    ]
   },
   {

--- a/viz_scripts/mode_purpose_share.ipynb
+++ b/viz_scripts/mode_purpose_share.ipynb
@@ -13,7 +13,9 @@
    "id": "colored-frost",
    "metadata": {},
    "source": [
-    "These are the input parameters for the notebook. They will be automatically changed when the scripts to generate monthly statistics are run. You can modify them manually to generate multiple plots locally as well. "
+    "These are the input parameters for the notebook. They will be automatically changed when the scripts to generate monthly statistics are run. You can modify them manually to generate multiple plots locally as well.\n",
+    "\n",
+    "Pass in `None` to remove the filters and plot all data. This is not recommended for production settings, but might be useful for reports based on data snapshots."
    ]
   },
   {
@@ -210,11 +212,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "german-apollo",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_suffix = scaffolding.get_file_suffix(year, month, program)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "tropical-pride",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax.figure.savefig(\"/plots/mode_confirm_%04d_%02d_%s.png\" % (year, month, program))"
+    "ax.figure.savefig(\"/plots/mode_confirm_%s.png\" % file_suffix)"
    ]
   },
   {
@@ -247,7 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax.figure.savefig(\"/plots/mode_confirm_misc_expand_%04d_%02d_%s.png\" % (year, month, program))"
+    "ax.figure.savefig(\"/plots/mode_confirm_misc_expand_%s.png\" % file_suffix)"
    ]
   },
   {

--- a/viz_scripts/scaffolding.py
+++ b/viz_scripts/scaffolding.py
@@ -12,7 +12,15 @@ import IPython.display as disp
 import emission.core.get_database as edb
 
 def get_time_query(year, month):
-    query_ld = ecwl.LocalDate({"year": year, "month": month})
+    if year is None and month is None:
+        return None
+
+    if month is None:
+        assert year is not None
+        query_ld = ecwl.LocalDate({"year": year})
+    else:
+        assert year is not None and month is not None
+        query_ld = ecwl.LocalDate({"year": year, "month": month})
     tq = esttc.TimeComponentQuery("data.start_local_dt", query_ld, query_ld)
     return tq
 
@@ -62,3 +70,16 @@ def expand_userinputs(labeled_ct):
             (len(expanded_ct.columns), len(labeled_ct.columns)))
     disp.display(expanded_ct.head())
     return expanded_ct
+
+def get_quality_text(participant_ct_df, expanded_ct):
+    cq = (len(expanded_ct), len(expanded_ct.user_id.unique()), len(participant_ct_df), len(participant_ct_df.user_id.unique()), (len(expanded_ct) * 100) / len(participant_ct_df), )
+    quality_text = "Based on %s confirmed trips from %d users\nof %s total trips from %d users (%.2f%%)" % cq
+    print(quality_text)
+    return quality_text
+
+def get_file_suffix(year, month, program):
+    suffix = "%04d" % year if year is not None else ""
+    suffix = suffix + "%02d" % month if month is not None else ""
+    suffix = suffix + "%s" % program if program is not None else ""
+    print(suffix)
+    return suffix


### PR DESCRIPTION
This makes it easier to generate plots for reports that work on data snapshots.

I assume we will not use them on production due to scalability concerns, but some of the more controlled aggregations (e.g. at the year level) might even be applicable there.

- Support "None" entries while generating the time query
- Support "None" entries while generating the file name
- Move the quality string to the scaffolding to make it easier to use