### PR TITLE
fix the filenames

### DIFF
--- a/viz_scripts/ebike_specific_metrics.ipynb
+++ b/viz_scripts/ebike_specific_metrics.ipynb
@@ -206,7 +206,7 @@
     "labels_tp = data_eb['Trip_purpose'].value_counts(dropna=True)[:10].keys().tolist()\n",
     "values_tp = data_eb['Trip_purpose'].value_counts(dropna=True)[:10].tolist()\n",
     "plot_title=\"Number of trips for each purpose for eBike only\\n%s\" % quality_text\n",
-    "file_name= 'ntrips_ebike_purpose_%s.png' % file_suffix\n",
+    "file_name= 'ntrips_ebike_purpose%s.png' % file_suffix\n",
     "pie_chart_purpose(plot_title,labels_tp,values_tp,file_name)"
    ]
   },
@@ -220,7 +220,7 @@
     "labels_eb = data_eb.Replaced_mode.value_counts(dropna=True)[:7].keys().tolist()\n",
     "values_eb = data_eb.Replaced_mode.value_counts(dropna=True)[:7].tolist()\n",
     "plot_title=\"Number of trips for each replaced transport mode for eBike only\\n%s\" % quality_text\n",
-    "file_name ='ntrips_ebike_replaced_mode_%s.png' % file_suffix\n",
+    "file_name ='ntrips_ebike_replaced_mode%s.png' % file_suffix\n",
     "pie_chart_mode(plot_title,labels_eb,values_eb,file_name)"
    ]
   },
@@ -255,7 +255,7 @@
     "labels = labels_m[:5]\n",
     "values = values_m[:5]\n",
     "plot_title=\"Distribution of Miles Replaced by Ebike \\n%s\" % quality_text\n",
-    "file_name ='miles_ebike_replaced_mode_%s.png' % file_suffix\n",
+    "file_name ='miles_ebike_replaced_mode%s.png' % file_suffix\n",
     "pie_chart_mode(plot_title,labels,values,file_name)\n",
     "print(dg)"
    ]

--- a/viz_scripts/energy_calculations.ipynb
+++ b/viz_scripts/energy_calculations.ipynb
@@ -191,7 +191,7 @@
     "y='distance_miles'\n",
     "legend ='Mode_confirm'\n",
     "plot_title=\"Sketch of Energy Impact (kWH) by Travel Mode Selected\\n%s\" % quality_text\n",
-    "file_name ='sketch_distance_energy_impact_%s.png' % file_suffix\n",
+    "file_name ='sketch_distance_energy_impact%s.png' % file_suffix\n",
     "distancevsenergy(data,x,y,legend,plot_title,file_name)"
    ]
   },
@@ -249,7 +249,7 @@
     "y= 'Transport Mode'\n",
     "color = 'selection'\n",
     "plot_title=\"Sketch of Energy Impact (kWH) by Transport Mode\\n%s\" % quality_text\n",
-    "file_name ='sketch_all_energy_impact_%s.png' % file_suffix\n",
+    "file_name ='sketch_all_energy_impact%s.png' % file_suffix\n",
     "overeall_energy_impact(x,y,color,df,plot_title,file_name)"
    ]
   },
@@ -275,7 +275,7 @@
     "color =eirc['boolean']\n",
     "\n",
     "plot_title=\"Sketch of Energy Impact for all confirmed trips \\n Contribution by mode towards a total of %s (kWH) \\n%s\" % (net_energy_saved, quality_text)\n",
-    "file_name ='sketch_all_mode_energy_impact_%s.png' % file_suffix\n",
+    "file_name ='sketch_all_mode_energy_impact%s.png' % file_suffix\n",
     "energy_impact(x,y,color,plot_title,file_name)"
    ]
   },
@@ -310,7 +310,7 @@
     "color =ebei['boolean']\n",
     "\n",
     "plot_title=\"Sketch of Energy Impact of E-Bike trips\\n Contribution by replaced mode towards a total of %s (kWH)\\n %s\" % (net_energy_saved, quality_text)\n",
-    "file_name ='sketch_energy_impact_ebike_%s.png' % file_suffix\n",
+    "file_name ='sketch_energy_impact_ebike%s.png' % file_suffix\n",
     "energy_impact(x,y,color,plot_title,file_name)"
    ]
   }

--- a/viz_scripts/generic_metrics_ebike_project.ipynb
+++ b/viz_scripts/generic_metrics_ebike_project.ipynb
@@ -1355,7 +1355,7 @@
     "labels_mc = expanded_ct['Mode_confirm'].value_counts(dropna=True)[:9].keys().tolist()\n",
     "values_mc = expanded_ct['Mode_confirm'].value_counts(dropna=True)[:9].tolist()\n",
     "plot_title= \"Number of trips for each mode (selected by users)\\n%s\" % quality_text\n",
-    "file_name= 'ntrips_mode_confirm_%s.png' % file_suffix\n",
+    "file_name= 'ntrips_mode_confirm%s.png' % file_suffix\n",
     "pie_chart_mode(plot_title,labels_mc,values_mc,file_name)"
    ]
   },
@@ -1388,7 +1388,7 @@
     "labels_rm = expanded_ct['Replaced_mode'].value_counts(dropna=True)[:10].keys().tolist()\n",
     "values_rm = expanded_ct['Replaced_mode'].value_counts(dropna=True)[:10].tolist()\n",
     "plot_title=\"Number of trips for each replaced mode (selected by users)\\n%s\" % quality_text\n",
-    "file_name= 'ntrips_replaced_mode_%s.png' % file_suffix\n",
+    "file_name= 'ntrips_replaced_mode%s.png' % file_suffix\n",
     "pie_chart_mode(plot_title,labels_rm,values_rm,file_name)"
    ]
   },
@@ -1452,7 +1452,7 @@
     "labels_tp = expanded_ct['Trip_purpose'].value_counts(dropna=True)[:10].keys().tolist()\n",
     "values_tp = expanded_ct['Trip_purpose'].value_counts(dropna=True)[:10].tolist()\n",
     "plot_title=\"Number of trips for each purposes (selected by users)\\n%s\" % quality_text\n",
-    "file_name= 'ntrips_purpose_%s.png' % file_suffix\n",
+    "file_name= 'ntrips_purpose%s.png' % file_suffix\n",
     "pie_chart_purpose(plot_title,labels_tp,values_tp,file_name)"
    ]
   },
@@ -1552,7 +1552,7 @@
     "labels_miles = labels_m[:5]\n",
     "values_miles = values_m[:5]\n",
     "plot_title=\"Miles for each mode (selected by users)\\n%s\" % quality_text\n",
-    "file_name ='miles_mode_confirm_%s.png' % file_suffix\n",
+    "file_name ='miles_mode_confirm%s.png' % file_suffix\n",
     "pie_chart_mode(plot_title,labels_miles,values_miles,file_name)\n",
     "print(miles)"
    ]

--- a/viz_scripts/scaffolding.py
+++ b/viz_scripts/scaffolding.py
@@ -80,9 +80,9 @@ def get_quality_text(participant_ct_df, expanded_ct):
     return quality_text
 
 def get_file_suffix(year, month, program):
-    suffix = "%04d" % year if year is not None else ""
-    suffix = suffix + "%02d" % month if month is not None else ""
-    suffix = suffix + "%s" % program if program is not None else ""
+    suffix = "_%04d" % year if year is not None else ""
+    suffix = suffix + "_%02d" % month if month is not None else ""
+    suffix = suffix + "_%s" % program if program is not None else ""
     print(suffix)
     return suffix
 


### PR DESCRIPTION
When we refactored the filename code as part of
https://github.com/e-mission/em-public-dashboard/commit/5a9264e72fe106395054a7d7e2e388672633123c
we removed the `_`

But then the filenames look like
ntrips_ebike_purpose_202011prepilot.png
instead of
ntrips_ebike_purpose_2020_11_prepilot.png

Fixing this by prepending `-` to the components, which then means that we have
to remove the trailing `_` from all filenames to avoid getting
ntrips_ebike_purpose__2020_11_prepilot.png