### PR TITLE
Fix the data load script

### DIFF
--- a/viz_scripts/docker/load_mongodump.sh
+++ b/viz_scripts/docker/load_mongodump.sh
@@ -1,7 +1,9 @@
 MONGODUMP_FILE=$1
 
-echo "Copying file to docker container"
-docker cp MONGODUMP_FILE em-public-dashboard_db_1:/tmp
+# echo "Copying file to docker container"
+# docker cp $MONGODUMP_FILE em-public-dashboard_db_1:/tmp
 
-echo "Restoring the dump"
-docker exec em-public-dashboard_db_1 bash -c 'cd /tmp && tar xvf $MONGODUMP_FILE && mongorestore'
+FILE_NAME=`basename $MONGODUMP_FILE`
+
+echo "Restoring the dump from $FILE_NAME"
+docker exec -e MONGODUMP_FILE=$FILE_NAME em-public-dashboard_db_1 bash -c 'cd /tmp && tar xvf $MONGODUMP_FILE && mongorestore'


### PR DESCRIPTION
This is an improvement to
3d9bbaa5502bcafe7b44de4ff2540d188cf9797c

We tried to copy the file directly and then load it, but ran into environment
variable expansion issues. Passing in the environment variable using `-e` fixes
that

+ use basename to get the filename instead of the directory