### PR TITLE
Handle small pie slices correctly by concatenating them into "other"

### DIFF
--- a/viz_scripts/ebike_specific_metrics.ipynb
+++ b/viz_scripts/ebike_specific_metrics.ipynb
@@ -203,8 +203,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "labels_tp = data_eb['Trip_purpose'].value_counts(dropna=True)[:10].keys().tolist()\n",
-    "values_tp = data_eb['Trip_purpose'].value_counts(dropna=True)[:10].tolist()\n",
+    "labels_tp = data_eb['Trip_purpose'].value_counts(dropna=True).keys().tolist()\n",
+    "values_tp = data_eb['Trip_purpose'].value_counts(dropna=True).tolist()\n",
     "plot_title=\"Number of trips for each purpose for eBike only\\n%s\" % quality_text\n",
     "file_name= 'ntrips_ebike_purpose%s.png' % file_suffix\n",
     "pie_chart_purpose(plot_title,labels_tp,values_tp,file_name)"
@@ -217,8 +217,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "labels_eb = data_eb.Replaced_mode.value_counts(dropna=True)[:7].keys().tolist()\n",
-    "values_eb = data_eb.Replaced_mode.value_counts(dropna=True)[:7].tolist()\n",
+    "labels_eb = data_eb.Replaced_mode.value_counts(dropna=True).keys().tolist()\n",
+    "values_eb = data_eb.Replaced_mode.value_counts(dropna=True).tolist()\n",
     "plot_title=\"Number of trips for each replaced transport mode for eBike only\\n%s\" % quality_text\n",
     "file_name ='ntrips_ebike_replaced_mode%s.png' % file_suffix\n",
     "pie_chart_mode(plot_title,labels_eb,values_eb,file_name)"
@@ -252,11 +252,9 @@
     "    labels_m.append(x)\n",
     "    values_m.append(y)\n",
     "\n",
-    "labels = labels_m[:5]\n",
-    "values = values_m[:5]\n",
     "plot_title=\"Distribution of Miles Replaced by Ebike \\n%s\" % quality_text\n",
     "file_name ='miles_ebike_replaced_mode%s.png' % file_suffix\n",
-    "pie_chart_mode(plot_title,labels,values,file_name)\n",
+    "pie_chart_mode(plot_title,labels_m,values_m,file_name)\n",
     "print(dg)"
    ]
   },

--- a/viz_scripts/generic_metrics_ebike_project.ipynb
+++ b/viz_scripts/generic_metrics_ebike_project.ipynb
@@ -194,11 +194,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "labels_mc = expanded_ct['Mode_confirm'].value_counts(dropna=True)[:9].keys().tolist()\n",
-    "values_mc = expanded_ct['Mode_confirm'].value_counts(dropna=True)[:9].tolist()\n",
+    "labels_mc = expanded_ct['Mode_confirm'].value_counts(dropna=True).keys().tolist()\n",
+    "values_mc = expanded_ct['Mode_confirm'].value_counts(dropna=True).tolist()\n",
     "plot_title= \"Number of trips for each mode (selected by users)\\n%s\" % quality_text\n",
     "file_name= 'ntrips_mode_confirm%s.png' % file_suffix\n",
-    "pie_chart_mode(plot_title,labels_mc,values_mc,file_name)"
+    "pie_chart_mode(plot_title,labels_mc,values_mc,file_name)\n",
+    "print(expanded_ct['Mode_confirm'].value_counts(dropna=True))"
    ]
   },
   {
@@ -216,8 +217,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "labels_rm = expanded_ct['Replaced_mode'].value_counts(dropna=True)[:10].keys().tolist()\n",
-    "values_rm = expanded_ct['Replaced_mode'].value_counts(dropna=True)[:10].tolist()\n",
+    "labels_rm = expanded_ct['Replaced_mode'].value_counts(dropna=True).keys().tolist()\n",
+    "values_rm = expanded_ct['Replaced_mode'].value_counts(dropna=True).tolist()\n",
     "plot_title=\"Number of trips for each replaced mode (selected by users)\\n%s\" % quality_text\n",
     "file_name= 'ntrips_replaced_mode%s.png' % file_suffix\n",
     "pie_chart_mode(plot_title,labels_rm,values_rm,file_name)"
@@ -257,11 +258,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "labels_tp = expanded_ct['Trip_purpose'].value_counts(dropna=True)[:10].keys().tolist()\n",
-    "values_tp = expanded_ct['Trip_purpose'].value_counts(dropna=True)[:10].tolist()\n",
+    "labels_tp = expanded_ct['Trip_purpose'].value_counts(dropna=True).keys().tolist()\n",
+    "values_tp = expanded_ct['Trip_purpose'].value_counts(dropna=True).tolist()\n",
     "plot_title=\"Number of trips for each purposes (selected by users)\\n%s\" % quality_text\n",
     "file_name= 'ntrips_purpose%s.png' % file_suffix\n",
-    "pie_chart_purpose(plot_title,labels_tp,values_tp,file_name)"
+    "pie_chart_purpose(plot_title,labels_tp,values_tp,file_name)\n",
+    "print(expanded_ct['Trip_purpose'].value_counts(dropna=True))"
    ]
   },
   {
@@ -279,11 +281,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "labels_d10 = expanded_ct.loc[(expanded_ct['distance_miles'] <= 10)].Mode_confirm.value_counts(dropna=True)[:10].keys().tolist()\n",
-    "values_d10 = expanded_ct.loc[(expanded_ct['distance_miles'] <= 10)].Mode_confirm.value_counts(dropna=True)[:10].tolist()\n",
+    "labels_d10 = expanded_ct.loc[(expanded_ct['distance_miles'] <= 10)].Mode_confirm.value_counts(dropna=True).keys().tolist()\n",
+    "values_d10 = expanded_ct.loc[(expanded_ct['distance_miles'] <= 10)].Mode_confirm.value_counts(dropna=True).tolist()\n",
     "plot_title=\"Mode confirmations for trips under 10 Miles\\n%s\" % quality_text\n",
     "file_name ='ntrips_under10miles_mode_confirm%s.png' % file_suffix\n",
-    "pie_chart_mode(plot_title,labels_d10,values_d10,file_name)"
+    "pie_chart_mode(plot_title,labels_d10,values_d10,file_name)\n",
+    "print(expanded_ct.loc[(expanded_ct['distance_miles'] <= 10)].Mode_confirm.value_counts(dropna=True))"
    ]
   },
   {
@@ -316,11 +319,9 @@
     "    labels_m.append(x)\n",
     "    values_m.append(y)\n",
     "\n",
-    "labels_miles = labels_m[:5]\n",
-    "values_miles = values_m[:5]\n",
     "plot_title=\"Miles for each mode (selected by users)\\n%s\" % quality_text\n",
     "file_name ='miles_mode_confirm%s.png' % file_suffix\n",
-    "pie_chart_mode(plot_title,labels_miles,values_miles,file_name)\n",
+    "pie_chart_mode(plot_title,labels_m,values_m,file_name)\n",
     "print(miles)"
    ]
   },


### PR DESCRIPTION
In order to avoid label overlaps, we were only plotting the first "n" entries.
This looked fine, but had some serious problems with stability as part of a system:
- the graph is misleading since it doesn't really represent all the data,
- the difference is small now, but this is guaranteed to break if we have an
  input like [10,10,10,10,5,5,5,5] when large chunks of data are going to go missing

Fix this by determining all slices < 2% and glomming them with any existing "Other" entries
We should have a way to explode the "Other" later, but this is at least not misleading in the interim

Changes:
- add a function to squish small wedges to the plotting code
- call it from all pie chart codes
- remove hardcoded subsetting in all the notebooks