### PR TITLE
Multiple fixex to the analysis scripts

### DIFF
--- a/viz_scripts/ebike_specific_metrics.ipynb
+++ b/viz_scripts/ebike_specific_metrics.ipynb
@@ -178,7 +178,7 @@
    "outputs": [],
    "source": [
     "# Energy Impact Calculation\n",
-    "expanded_ct = scaffolding.energy_cal(expanded_ct,dic_ei)"
+    "scaffolding.unit_conversions(expanded_ct)"
    ]
   },
   {

--- a/viz_scripts/energy_calculations.ipynb
+++ b/viz_scripts/energy_calculations.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "united-feeding",
    "metadata": {},
    "source": [
     "## Generate static graphs"
@@ -9,6 +10,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "outdoor-celebrity",
    "metadata": {},
    "source": [
     "These are the input parameters for the notebook. They will be automatically changed when the scripts to generate monthly statistics are run. You can modify them manually to generate multiple plots locally as well.\n",
@@ -19,6 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "determined-matrix",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,6 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "pharmaceutical-survival",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,6 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "inner-desktop",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,6 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "terminal-machinery",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,6 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "official-beatles",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,6 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "special-davis",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,6 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "above-network",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,6 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "revolutionary-lounge",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,6 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "abroad-myanmar",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,6 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cultural-salad",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,6 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "improved-venture",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,6 +159,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "micro-wound",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scaffolding.unit_conversions(expanded_ct)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efficient-marking",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,6 +179,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "caring-aruba",
    "metadata": {},
    "source": [
     "# Energy Impact (kWH) Calculation"
@@ -163,6 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dimensional-bronze",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,6 +198,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "sized-drain",
    "metadata": {},
    "source": [
     "# Distance vs. Energy_Impact (kWH) by Mode_confirm"
@@ -180,6 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "protecting-falls",
    "metadata": {
     "scrolled": false
    },
@@ -196,6 +224,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ready-return",
    "metadata": {},
    "source": [
     "# Energy_Impact (kWH)"
@@ -204,6 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "adequate-oriental",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,6 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "mechanical-error",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,6 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "unknown-venice",
    "metadata": {
     "scrolled": false
    },
@@ -260,6 +292,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "loose-puppy",
    "metadata": {},
    "source": [
     "# Sketch of Total Energy_Impact (kWH) by Replaced_mode"
@@ -268,6 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "emotional-universal",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,6 +318,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "advanced-complexity",
    "metadata": {},
    "source": [
     "# Sketch of Energy Impact by E-bike trips"
@@ -292,6 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dense-programmer",
    "metadata": {
     "scrolled": false
    },
@@ -317,6 +353,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "exact-utility",
    "metadata": {},
    "source": [
     "# CO2 Emissions (lb) Calculation"
@@ -325,6 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fallen-yugoslavia",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,6 +371,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "crazy-retreat",
    "metadata": {},
    "source": [
     "# Sketch of Total CO2 Emissions by Replaced_mode"
@@ -341,6 +380,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "annoying-vault",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,6 +404,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "strategic-sheet",
    "metadata": {},
    "source": [
     "# Sketch of  CO2 Emissions Impact by E-bike trips"
@@ -372,6 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "animated-place",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +452,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/viz_scripts/generic_metrics_ebike_project.ipynb
+++ b/viz_scripts/generic_metrics_ebike_project.ipynb
@@ -173,12 +173,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "every-zimbabwe",
+   "id": "advanced-newfoundland",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Energy Impact Calculation\n",
-    "expanded_ct = scaffolding.energy_cal(expanded_ct,dic_ei)"
+    "scaffolding.unit_conversions(expanded_ct)"
    ]
   },
   {
@@ -473,7 +472,8 @@
     "\n",
     "barplot_day(data,x,y,plot_title,file_name)"
    ]
-  },
+  }
+ ],
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3",

--- a/viz_scripts/mapping_dictionaries.ipynb
+++ b/viz_scripts/mapping_dictionaries.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "available-fusion",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,6 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "obvious-chapter",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,6 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "younger-indication",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +57,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/viz_scripts/scaffolding.py
+++ b/viz_scripts/scaffolding.py
@@ -103,6 +103,9 @@ def data_quality_check(expanded_ct):
     
     return expanded_ct
 
+def unit_conversions(df):
+    df['distance_miles']= df["distance"]*0.00062 #meters to miles
+
 def energy_intensity(df,df1,distance,col1,col2):
     """ Inputs:
     df = dataframe with data
@@ -112,7 +115,6 @@ def energy_intensity(df,df1,distance,col1,col2):
     col2= Mode_confirm
 
     """
-    df['distance_miles']= df[distance]*0.00062 #meters to miles
     df1 = df1.copy()
     df1[col1] = df1['mode']
     dic_ei_factor = dict(zip(df1[col1],df1['energy_intensity_factor']))


### PR DESCRIPTION
- remove the references to the obsolete `energy_cal` function from the ebike
  and generic metrics notebooks
- move the `distance_miles` calculation from the `energy_intensity` function to
  a separate function called `unit_conversions` since we need it in all notebooks
- fix the formatting of the `generic_metrics_ebike_project`, was probably
  broken in some earlier merge.