### PR TITLE
Switch to a pinned image instead of building the Dockerfile

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@ services:
     networks:
        - emission
   notebook-server:
-    build: viz_scripts/docker
+    image: emission/em-public-dashboard-notebook:1.0.0
     depends_on:
       - db
     environment:


### PR DESCRIPTION
This allows us to get around the bitrotted notebook environment and avoid
blocking interns. We will eventually have to upgrade to the latest version of
everything, but can defer that until June when we will have more intern support.

This is a workaround for https://github.com/e-mission/em-public-dashboard/issues/37