### PR TITLE
Add Timeseries Notebook Plots

### DIFF
--- a/frontend/metrics.html
+++ b/frontend/metrics.html
@@ -11,3 +11,13 @@
 <option value="ntrips_ebike_per_day" data-sizex="6" data-sizey="4">eBike Trip frequency</option>
 <option value="sketch_energy_impact_ebike" data-sizex="6" data-sizey="4">Sketch of eBike energy impact</option>
 <option value="sketch_CO2impact_ebike" data-sizex="6" data-sizey="4">Sketch of eBike emission impact</option>
+<option value="ts_emissions_user" data-sizex="8" data-sizey="4">Timeseries of emissions</option>
+<option value="ts_energy_user" data-sizex="8" data-sizey="4">Timeseries of energy</option>
+<option value="ts_emissions_vmt" data-sizex="8" data-sizey="4">Timeseries of emissions per mile</option>
+<option value="ts_mode_share" data-sizex="8" data-sizey="4">Timeseries of mode share (single user)</option>
+<option value="ts_users" data-sizex="8" data-sizey="4">Timeseries of active users</option>
+<option value="ts_ebike_share" data-sizex="8" data-sizey="4">Timeseries of eBike trips</option>
+<option value="ts_ebike_miles" data-sizex="8" data-sizey="4">Timeseries of eBike mode share</option>
+<option value="ts_ebike_miles_user" data-sizex="8" data-sizey="4">Timeseries of eBike miles per user</option>
+<option value="ts_all_modes" data-sizex="8" data-sizey="4">Timeseries of all mode shares</option>
+<option value="ts_ebike_mile_individual" data-sizex="8" data-sizey="4">Timeseries of eBike proportion of individual mileage</option>

--- a/viz_scripts/docker/crontab
+++ b/viz_scripts/docker/crontab
@@ -2,5 +2,6 @@
 0 8 * * * python bin/generate_plots.py ebike_specific_metrics prepilot >> /var/log/intake.stdinout 2>&1
 0 8 * * * python bin/generate_plots.py energy_calculations.ipynb prepilot >> /var/log/intake.stdinout 2>&1
 0 8 * * * python bin/generate_plots.py generic_metrics_ebike_project.ipynb prepilot >> /var/log/intake.stdinout 2>&1
+0 8 * * * python bin/generate_plots.py timeseries_analysis.ipynb prepilot >> /var/log/intake.stdinout 2>&1
 # For testing only
 # */5 * * * * python bin/generate_plots.py mode_purpose_share.ipynb prepilot >> /var/log/intake.stdinout 2>&1

--- a/viz_scripts/timeseries_analysis.ipynb
+++ b/viz_scripts/timeseries_analysis.ipynb
@@ -162,7 +162,7 @@
    "outputs": [],
    "source": [
     "# Calculate energy impact\n",
-    "expanded_ct = scaffolding.energy_intensity(expanded_ct, df_EI, 'Replaced_mode', 'Mode_confirm')\n",
+    "expanded_ct = scaffolding.energy_intensity(expanded_ct, df_EI, 'distance_miles', 'Replaced_mode', 'Mode_confirm')\n",
     "expanded_ct = scaffolding.energy_impact_kWH(expanded_ct, 'distance_miles', 'Replaced_mode', 'Mode_confirm')\n",
     "expanded_ct = scaffolding.CO2_impact_lb(expanded_ct, 'distance_miles', 'Replaced_mode', 'Mode_confirm')"
    ]
@@ -217,7 +217,7 @@
    },
    "outputs": [],
    "source": [
-    "# Count the number of trips for each sensed mode\n",
+    "# Count the number of trips for each confirmed mode\n",
     "mode_counts = data.groupby(['user_id','date_time','Mode_confirm'], as_index=False).size()\n",
     "mode_counts.rename(columns={'size':'trip_count'}, inplace=True)\n",
     "\n",
@@ -252,15 +252,6 @@
    "metadata": {},
    "source": [
     "### Generate Timeseries Plots"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "file_suffix = scaffolding.get_file_suffix(year, month, program)"
    ]
   },
   {
@@ -432,7 +423,10 @@
    "source": [
     "# Plot of ebike mode share across many individual users\n",
     "# This plot is a little crazy if the number of users displayed is not limited\n",
-    "plot_data = mode_distance[mode_distance['Mode_confirm']=='Pilot ebike']\n",
+    "# For now use the first 20 IDs\n",
+    "test_uuids = pd.unique(mode_distance['user_id'])[:19]\n",
+    "plot_data = mode_distance[mode_distance['user_id'].isin(test_uuids)]\n",
+    "plot_data = plot_data[plot_data['Mode_confirm']=='Pilot ebike']\n",
     "plot_data = plot_data.groupby(['user_id','date_time'], as_index=False)['distance_miles_smooth'].sum()\n",
     "total_miles = mode_distance.groupby(['user_id','date_time'], as_index=False)['distance_miles_smooth'].sum()\n",
     "plot_data = plot_data.merge(total_miles, on=['user_id','date_time'])\n",
@@ -440,7 +434,7 @@
     "plot_data['user_id'] = plot_data['user_id'].astype(str).str[-4:]\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(16,4))\n",
-    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='miles_proportion', hue='user_id', legend=False).set(title='Daily Ebike Mileage Proportion (Individual)', xlabel='Date', ylabel='Proportion of User Daily Miles')\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='miles_proportion', hue='user_id', legend=False, palette=\"Set1\").set(title='Daily Ebike Mileage Proportion (Individual)', xlabel='Date', ylabel='Proportion of User Daily Miles')\n",
     "plt.xticks(rotation=45)\n",
     "plt.subplots_adjust(bottom=0.25)\n",
     "ax.figure.savefig(\"/plots/ts_ebike_mile_individual%s.png\" % file_suffix)"

--- a/viz_scripts/timeseries_analysis.ipynb
+++ b/viz_scripts/timeseries_analysis.ipynb
@@ -1,0 +1,471 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "year = None\n",
+    "month = None\n",
+    "program = \"prepilot\"\n",
+    "user_id_plot = '9910245f-ee4e-4cca-ab4c-dd2312eb0d5d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import defaultdict\n",
+    "import datetime\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "\n",
+    "import emission.core.get_database as edb\n",
+    "import emission.core.wrapper.entry as ecwe\n",
+    "import emission.storage.decorations.analysis_timeseries_queries as esda\n",
+    "import emission.storage.decorations.trip_queries as esdt\n",
+    "import emission.storage.decorations.timeline as esdl\n",
+    "import emission.storage.timeseries.abstract_timeseries as esta\n",
+    "import emission.storage.timeseries.timequery as estt\n",
+    "from uuid import UUID\n",
+    "\n",
+    "sns.set_style(\"whitegrid\")\n",
+    "sns.set()\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scaffolding\n",
+    "from plots import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Collect Data From Database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Loading mapping dictionaries from mapping_dictionaries notebook\n",
+    "%store -r df_EI\n",
+    "%store -r dic_re\n",
+    "%store -r dic_pur\n",
+    "%store -r dic_fuel\n",
+    "\n",
+    "# convert a dictionary to a defaultdict\n",
+    "dic_pur = defaultdict(lambda: 'Other',dic_pur)\n",
+    "dic_re = defaultdict(lambda: 'Other',dic_re)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tq = scaffolding.get_time_query(year, month)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "participant_ct_df = scaffolding.load_all_participant_trips(program, tq)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labeled_ct = scaffolding.filter_labeled_trips(participant_ct_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expanded_ct = scaffolding.expand_userinputs(labeled_ct)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expanded_ct = scaffolding.data_quality_check(expanded_ct)\n",
+    "expanded_ct.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mapping new labels with dictionaries\n",
+    "expanded_ct['Trip_purpose']= expanded_ct['purpose_confirm'].map(dic_pur)\n",
+    "expanded_ct['Mode_confirm']= expanded_ct['mode_confirm'].map(dic_re)\n",
+    "expanded_ct['Replaced_mode']= expanded_ct['replaced_mode'].map(dic_re)\n",
+    "\n",
+    "# Mapping fuel\n",
+    "expanded_ct['Mode_confirm_fuel']= expanded_ct['Mode_confirm'].map(dic_fuel)\n",
+    "expanded_ct['Replaced_mode_fuel']= expanded_ct['Replaced_mode'].map(dic_fuel)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change meters to miles\n",
+    "scaffolding.unit_conversions(expanded_ct)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_suffix = scaffolding.get_file_suffix(year, month, program)\n",
+    "quality_text = scaffolding.get_quality_text(participant_ct_df, expanded_ct)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate energy impact\n",
+    "expanded_ct = scaffolding.energy_intensity(expanded_ct, df_EI, 'Replaced_mode', 'Mode_confirm')\n",
+    "expanded_ct = scaffolding.energy_impact_kWH(expanded_ct, 'distance_miles', 'Replaced_mode', 'Mode_confirm')\n",
+    "expanded_ct = scaffolding.CO2_impact_lb(expanded_ct, 'distance_miles', 'Replaced_mode', 'Mode_confirm')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data Preprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get timestamp from known year/month/day aggregated to days\n",
+    "data = expanded_ct[['user_id','start_local_dt_year','start_local_dt_month','start_local_dt_day','Mode_confirm','Mode_confirm_EI(kWH)','Mode_confirm_lb_CO2','distance_miles']].copy()\n",
+    "data.rename(columns={'start_local_dt_year':'year','start_local_dt_month':'month','start_local_dt_day':'day'}, inplace=True)\n",
+    "data['date_time'] = pd.to_datetime(data[['year','month','day']])\n",
+    "data = data.drop(columns=['year','month','day'])\n",
+    "\n",
+    "# Categorical type will include all days/modes in groupby even if there is no data for a particular tabulation\n",
+    "data.user_id = pd.Categorical(data.user_id)\n",
+    "data.date_time = pd.Categorical(data.date_time)\n",
+    "data.Mode_confirm = pd.Categorical(data.Mode_confirm,\n",
+    "                                   ordered=True,\n",
+    "                                   categories=['Car, drove alone',\n",
+    "                                              'Car, with others',\n",
+    "                                              'Taxi/Uber/Lyft',\n",
+    "                                              'Bus',\n",
+    "                                              'Free Shuttle',\n",
+    "                                              'Train',\n",
+    "                                              'Bikeshare',\n",
+    "                                              'Pilot ebike',\n",
+    "                                              'Regular Bike',\n",
+    "                                              'Scooter share',\n",
+    "                                              'Skate board',\n",
+    "                                              'Walk',\n",
+    "                                              'Other',\n",
+    "                                              'Not a Trip'])\n",
+    "\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Count the number of trips for each sensed mode\n",
+    "mode_counts = data.groupby(['user_id','date_time','Mode_confirm'], as_index=False).size()\n",
+    "mode_counts.rename(columns={'size':'trip_count'}, inplace=True)\n",
+    "\n",
+    "# Sum daily distance traveled for each mode\n",
+    "mode_distance = data.groupby(['user_id','date_time','Mode_confirm'], as_index=False)[['distance_miles']].sum()\n",
+    "mode_distance.rename(columns={'sum':'distance_miles'}, inplace=True)\n",
+    "mode_distance['distance_miles'] = mode_distance['distance_miles'].fillna(0)\n",
+    "\n",
+    "# Sum daily emissions for each user\n",
+    "emissions = data.groupby(['user_id','date_time'], as_index=False)[['Mode_confirm_lb_CO2', 'distance_miles']].sum()\n",
+    "emissions['Mode_confirm_lb_CO2'] = emissions['Mode_confirm_lb_CO2'].fillna(0)\n",
+    "emissions['distance_miles'] = emissions['Mode_confirm_lb_CO2'].fillna(0)\n",
+    "\n",
+    "# Sum daily energy for each user\n",
+    "energy = data.groupby(['user_id','date_time'], as_index=False)[['Mode_confirm_EI(kWH)', 'distance_miles']].sum()\n",
+    "energy['Mode_confirm_EI(kWH)'] = energy['Mode_confirm_EI(kWH)'].fillna(0)\n",
+    "energy['distance_miles'] = energy['Mode_confirm_EI(kWH)'].fillna(0)\n",
+    "\n",
+    "# Get the count of unique users that were active on each given date\n",
+    "active_users = pd.DataFrame(data.groupby(['date_time'], as_index=False)['user_id'].nunique())\n",
+    "active_users.rename(columns={'user_id':'active_users'}, inplace=True)\n",
+    "\n",
+    "# Add 7-day rolling avg smoothing to better see trends\n",
+    "mode_counts['trip_count_smooth'] = mode_counts.groupby(['user_id','Mode_confirm'])['trip_count'].apply(lambda x: x.rolling(7,1).mean())\n",
+    "mode_distance['distance_miles_smooth'] = mode_distance.groupby(['user_id','Mode_confirm'])['distance_miles'].apply(lambda x: x.rolling(7,1).mean())\n",
+    "emissions['distance_miles_smooth'] = emissions.groupby(['user_id'])['distance_miles'].apply(lambda x: x.rolling(7,1).mean())\n",
+    "energy['distance_miles_smooth'] = energy.groupby(['user_id'])['distance_miles'].apply(lambda x: x.rolling(7,1).mean())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate Timeseries Plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_suffix = scaffolding.get_file_suffix(year, month, program)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Emissions per week across all users (net impact)\n",
+    "plot_data = emissions.groupby(['date_time'], as_index=False)['Mode_confirm_lb_CO2'].agg(['sum'])\n",
+    "plot_data = plot_data.merge(active_users, on='date_time')\n",
+    "plot_data['sum'] = plot_data['sum'] / plot_data['active_users']\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16,4))\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='sum').set(title='Net Daily Emissions (All Users)', xlabel='Date', ylabel='Emissions (lb CO2/day/user)')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.subplots_adjust(bottom=0.25)\n",
+    "ax.figure.savefig(\"/plots/ts_emissions_user%s.png\" % file_suffix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Energy per week across all users (net impact)\n",
+    "plot_data = energy.groupby(['date_time'], as_index=False)['Mode_confirm_EI(kWH)'].agg(['sum'])\n",
+    "plot_data = plot_data.merge(active_users, on='date_time')\n",
+    "plot_data['sum'] = plot_data['sum'] / plot_data['active_users']\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16,4))\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='sum').set(title='Net Daily Energy (All Users)', xlabel='Date', ylabel='Energy (kWH/day/user)')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.subplots_adjust(bottom=0.25)\n",
+    "ax.figure.savefig(\"/plots/ts_energy_user%s.png\" % file_suffix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Emissions per mile per day across all users (travel efficiency)\n",
+    "# Note that the energy plot will be identical to this one since scale factor is divided out\n",
+    "emissions['CO2_per_mile'] = emissions['Mode_confirm_lb_CO2'] / emissions['distance_miles_smooth']\n",
+    "emissions['CO2_per_mile'] = emissions['CO2_per_mile'].fillna(0)\n",
+    "plot_data = emissions.groupby(['date_time'], as_index=False)['CO2_per_mile'].agg(['mean'])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16,4))\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='mean').set(title='Average Daily Emission Rate (All Users)', xlabel='Date', ylabel='Emissions (lb CO2/mile/day)')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.subplots_adjust(bottom=0.25)\n",
+    "ax.figure.savefig(\"/plots/ts_emissions_vmt%s.png\" % file_suffix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot of all mode shares for single individual\n",
+    "plot_data = mode_counts[mode_counts['user_id']==UUID(user_id_plot)]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16,4))\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='trip_count_smooth', hue='Mode_confirm', style='Mode_confirm', palette='Set1').set(title=f'Mode Share (User {user_id_plot})', xlabel='Date', ylabel='Trip Count')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.subplots_adjust(bottom=0.25)\n",
+    "plt.legend(loc='center left', title='Confirmed Mode')\n",
+    "ax.figure.savefig(\"/plots/ts_mode_share%s.png\" % file_suffix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot of active users\n",
+    "plot_data = active_users\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16,4))\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='active_users').set(title='Number of Active Users', xlabel='Date', ylabel='Unique IDs')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.subplots_adjust(bottom=0.25)\n",
+    "ax.figure.savefig(\"/plots/ts_users%s.png\" % file_suffix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot of total ebikeshare trips across all users\n",
+    "plot_data = mode_counts[mode_counts['Mode_confirm']=='Pilot ebike']\n",
+    "plot_data = plot_data.groupby(['date_time'], as_index=False)['trip_count_smooth'].agg(['sum'])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16,4))\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='sum').set(title='Daily E-Bike Trips', xlabel='Date', ylabel='Trip Count')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.subplots_adjust(bottom=0.25)\n",
+    "ax.figure.savefig(\"/plots/ts_ebike_share%s.png\" % file_suffix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot of total ebikeshare mileage across all users\n",
+    "plot_data = data[data['Mode_confirm']=='Pilot ebike']\n",
+    "plot_data = plot_data.groupby(['date_time'], as_index=False)['distance_miles'].agg(['sum'])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16,4))\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='sum').set(title='Daily E-Bike Mileage', xlabel='Date', ylabel='Miles')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.subplots_adjust(bottom=0.25)\n",
+    "ax.figure.savefig(\"/plots/ts_ebike_miles%s.png\" % file_suffix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot of total ebikeshare mileage normalized by number of users\n",
+    "plot_data = data[data['Mode_confirm']=='Pilot ebike']\n",
+    "plot_data = plot_data.groupby(['date_time'], as_index=False)['distance_miles'].agg(['sum'])\n",
+    "plot_data = plot_data.merge(active_users, on='date_time')\n",
+    "plot_data['mileage_per_user'] = plot_data['sum'] / plot_data['active_users']\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16,4))\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='mileage_per_user').set(title='Daily E-Bike Mileage per Active User', xlabel='Date', ylabel='miles/user')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.subplots_adjust(bottom=0.25)\n",
+    "ax.figure.savefig(\"/plots/ts_ebike_miles_user%s.png\" % file_suffix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot of mode share proportions across all users\n",
+    "plot_data = mode_counts.groupby(['date_time','Mode_confirm'], as_index=False)['trip_count_smooth'].sum()\n",
+    "total_trips = plot_data.groupby(['date_time'], as_index=False).sum()\n",
+    "plot_data = plot_data.merge(total_trips, on='date_time')\n",
+    "plot_data['trip_proportion'] = plot_data['trip_count_smooth_x'] / plot_data['trip_count_smooth_y']\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16,4))\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='trip_proportion', hue='Mode_confirm').set(title='Daily Aggregate Mode Share', xlabel='Date', ylabel='Proportion of All Trips')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.subplots_adjust(bottom=0.25)\n",
+    "plt.legend(loc='center left', title='Confirmed Mode')\n",
+    "ax.figure.savefig(\"/plots/ts_all_modes%s.png\" % file_suffix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot of ebike mode share across many individual users\n",
+    "# This plot is a little crazy if the number of users displayed is not limited\n",
+    "plot_data = mode_distance[mode_distance['Mode_confirm']=='Pilot ebike']\n",
+    "plot_data = plot_data.groupby(['user_id','date_time'], as_index=False)['distance_miles_smooth'].sum()\n",
+    "total_miles = mode_distance.groupby(['user_id','date_time'], as_index=False)['distance_miles_smooth'].sum()\n",
+    "plot_data = plot_data.merge(total_miles, on=['user_id','date_time'])\n",
+    "plot_data['miles_proportion'] = plot_data['distance_miles_smooth_x'] / plot_data['distance_miles_smooth_y']\n",
+    "plot_data['user_id'] = plot_data['user_id'].astype(str).str[-4:]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(16,4))\n",
+    "sns.lineplot(ax=ax, data=plot_data, x='date_time', y='miles_proportion', hue='user_id', legend=False).set(title='Daily Ebike Mileage Proportion (Individual)', xlabel='Date', ylabel='Proportion of User Daily Miles')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.subplots_adjust(bottom=0.25)\n",
+    "ax.figure.savefig(\"/plots/ts_ebike_mile_individual%s.png\" % file_suffix)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
- Creates a notebook called "timeseries_analysis" that contains plots over time for various aspects of the OpenPATH data
- Follows structure of other plotting notebooks for gathering data from the db, and having user enter inputs in the first cell
- Adds entries to the frontend list which allow the plots to be loaded into the public dashboard