### PR TITLE
Changes to added python files to support the NREL hosted version

### DIFF
--- a/viz_scripts/auxiliary_files/energy_intensity.csv
+++ b/viz_scripts/auxiliary_files/energy_intensity.csv
@@ -1,6 +1,8 @@
 ﻿mode,fuel,(kWH)/trip,EI(kWH/PMT),energy_intensity_factor,energy_intensity_units,CO2_factor,CO2_factor_units
-"Car, drove alone",gasoline,0,,5170,BTU/PMT,157.2,lb_CO2/MMBTU
-"Car, with others",gasoline,0,,2585,BTU/PMT,157.2,lb_CO2/MMBTU
+"Gas Car, drove alone",gasoline,0,,5170,BTU/PMT,157.2,lb_CO2/MMBTU
+"Gas Car, with others",gasoline,0,,2585,BTU/PMT,157.2,lb_CO2/MMBTU
+"E-car, drove alone",electric,0,0.25,0.25,kWH/PMT,1166,lb_CO2/MWH
+"E-car, with others",electric,0,0.125,0.125,kWH/PMT,1166,lb_CO2/MWH
 Taxi/Uber/Lyft,gasoline,0,,7214,BTU/PMT,157.2,lb_CO2/MMBTU
 Bus,diesel,0,,4560,BTU/PMT,161.3,lb_CO2/MMBTU
 Free Shuttle,diesel,0,,4560,BTU/PMT,161.3,lb_CO2/MMBTU

--- a/viz_scripts/auxiliary_files/mode_labels.csv
+++ b/viz_scripts/auxiliary_files/mode_labels.csv
@@ -1,25 +1,28 @@
 ﻿replaced_mode,mode_confirm,mode_clean
-drove_alone,drove_alone,"Car, drove alone"
-work_vehicle,work_vehicle,"Car, drove alone"
+drove_alone,drove_alone,"Gas Car, drove alone"
+e_car_drove_alone,e_car_drove_alone,"E-car, drove alone"
+work_vehicle,work_vehicle,"Gas Car, drove alone"
 bus,bus,Bus
 train,train,Train
 free_shuttle,free_shuttle,Free Shuttle
 "train,_bus and walk","train,_bus and walk",Train
 train_and pilot e-bike,train_and pilot e-bike,Train
 taxi,taxi,Taxi/Uber/Lyft
-friend_picked me up,friend_picked me up,"Car, with others"
-carpool_w/ friend to work,carpool_w/ friend to work,"Car, with others"
-friend_carpool to work,friend_carpool to work,"Car, with others"
-carpool_to work,carpool_to work,"Car, with others"
-friend/co_worker carpool,friend/co_worker carpool,"Car, with others"
-carpool_to lunch,carpool_to lunch,"Car, with others"
-carpool,carpool,"Car, with others"
-carpool_for lunch,carpool_for lunch,"Car, with others"
-carpool_lunch,carpool_lunch,"Car, with others"
-shared_ride,shared_ride,"Car, with others"
+friend_picked me up,friend_picked me up,"Gas Car, with others"
+carpool_w/ friend to work,carpool_w/ friend to work,"Gas Car, with others"
+friend_carpool to work,friend_carpool to work,"Gas Car, with others"
+carpool_to work,carpool_to work,"Gas Car, with others"
+friend/co_worker carpool,friend/co_worker carpool,"Gas Car, with others"
+carpool_to lunch,carpool_to lunch,"Gas Car, with others"
+carpool,carpool,"Gas Car, with others"
+carpool_for lunch,carpool_for lunch,"Gas Car, with others"
+carpool_lunch,carpool_lunch,"Gas Car, with others"
+shared_ride,shared_ride,"Gas Car, with others"
+e_car_shared_ride,e_car_shared_ride,"E-car, with others"
 bikeshare,bikeshare,Bikeshare
 scootershare,scootershare,Scooter share
-pilot_ebike,pilot_ebike,Pilot ebike
+pilot_ebike,pilot_ebike,E-bike
+e-bike,e-bike,E-bike
 walk,walk,Walk
 skateboard,skateboard,Skate board
 bike,bike,Regular Bike

--- a/viz_scripts/plots.py
+++ b/viz_scripts/plots.py
@@ -49,21 +49,24 @@ def merge_small_entries(labels, values):
     return (v2l_df.index.to_list(),v2l_df.vals.to_list())
 
 def pie_chart_mode(plot_title,labels,values,file_name):
-    all_labels= ['Car, drove alone',
+    all_labels= ['Gas Car, drove alone',
                  'Bus', 
                  'Train', 
                  'Free Shuttle',
                  'Taxi/Uber/Lyft', 
-                 'Car, with others', 
+                 'Gas Car, with others', 
                  'Bikeshare',
                  'Scooter share',
-                 'Pilot ebike', 
+                 'E-bike', 
                  'Walk', 
                  'Skate board', 
                  'Regular Bike', 
                  'Not a Trip',
                  'No Travel', 
                  'Same Mode', 
+                 'E-car, drove alone',
+                 'E-car, with others',
+                 'Air',
                  'Other']
 
     val2labeldf = pd.DataFrame({"labels": labels, "values": values})
@@ -140,7 +143,7 @@ def distancevsenergy(data,x,y,legend,plot_title,file_name):
                  'Car, with others', 
                  'Bikeshare',
                  'Scooter share',
-                 'Pilot ebike', 
+                 'E-bike', 
                  'Walk', 
                  'Skate board', 
                  'Regular Bike', 
@@ -235,21 +238,24 @@ def energy_impact(x,y,color,plot_title,file_name):
     
     
 def barplot_mode(data,x,y,plot_title,file_name):
-    all_labels= ['Car, drove alone',
+    all_labels= ['Gas Car, drove alone',
                  'Bus', 
                  'Train', 
                  'Free Shuttle',
                  'Taxi/Uber/Lyft', 
-                 'Car, with others', 
+                 'Gas Car, with others', 
                  'Bikeshare',
                  'Scooter share',
-                 'Pilot ebike', 
+                 'E-bike', 
                  'Walk', 
                  'Skate board', 
                  'Regular Bike', 
                  'Not a Trip',
                  'No Travel', 
                  'Same Mode', 
+                 'E-car, drove alone',
+                 'E-car, with others',
+                 'Air',
                  'Other']
     
     colours = dict(zip(all_labels, plt.cm.tab20.colors[:len(all_labels)]))
@@ -265,21 +271,24 @@ def barplot_mode(data,x,y,plot_title,file_name):
     
 
 def barplot_mode2(data,x,y,y2,plot_title,file_name):
-    all_labels= ['Car, drove alone',
+    all_labels= ['Gas Car, drove alone',
                  'Bus', 
                  'Train', 
                  'Free Shuttle',
                  'Taxi/Uber/Lyft', 
-                 'Car, with others', 
+                 'Gas Car, with others', 
                  'Bikeshare',
                  'Scooter share',
-                 'Pilot ebike', 
+                 'E-bike', 
                  'Walk', 
                  'Skate board', 
                  'Regular Bike', 
                  'Not a Trip',
                  'No Travel', 
                  'Same Mode', 
+                 'E-car, drove alone',
+                 'E-car, with others',
+                 'Air',
                  'Other']
     
     colours = dict(zip(all_labels, plt.cm.tab20.colors[:len(all_labels)]))

--- a/viz_scripts/scaffolding.py
+++ b/viz_scripts/scaffolding.py
@@ -28,13 +28,14 @@ def get_time_query(year, month):
 
 def get_participant_uuids(program):
     """
-        Get the list of participant UUIDs for the specified program.
-        Note that the "program" parameter is currently a NOP but will be enabled
-        once we have other programs start
+        Get the list of non-test users in the current program.
+        Note that the "program" parameter is currently a NOP and should be removed in
+        conjunction with modifying the notebooks.
     """
-    participant_uuid_obj = list(edb.get_profile_db().find({}))
-    participant_uuid_str = [u["user_id"] for u in participant_uuid_obj]
-    disp.display(participant_uuid_str)
+    all_users = pd.json_normalize(edb.get_uuid_db().find())
+    participant_list = all_users[np.logical_not(all_users.user_email.str.contains("_test_"))]
+    participant_uuid_str = participant_list.uuid
+    disp.display(participant_list.user_email)
     return participant_uuid_str
 
 def load_all_confirmed_trips(tq):
@@ -58,7 +59,14 @@ def filter_labeled_trips(mixed_trip_df):
     disp.display(labeled_ct.head())
     return labeled_ct
 
-def expand_userinputs(labeled_ct):
+def expand_userinputs(labeled_ct, labels_per_trip):
+    '''
+    param: labeled_ct: a dataframe of confirmed trips, some of which have labels
+    params: labels_per_trip: the number of labels for each trip.
+        Currently, this is 2 for studies and 3 for programs, and should be 
+        passed in by the notebook based on the input config.
+        If used with a trip-level survey, it could be even larger.
+    '''
     label_only = pd.DataFrame(labeled_ct.user_input.to_list(), index=labeled_ct.index)
     disp.display(label_only.head())
     expanded_ct = pd.concat([labeled_ct, label_only], axis=1)
@@ -67,7 +75,7 @@ def expand_userinputs(labeled_ct):
             (len(expanded_ct), len(labeled_ct)))
     print("After expanding, columns went from %s -> %s" %
         (len(labeled_ct.columns), len(expanded_ct.columns)))
-    assert len(expanded_ct.columns) == len(labeled_ct.columns) + 3, \
+    assert len(expanded_ct.columns) == len(labeled_ct.columns) + labels_per_trip, \
         ("Mismatch after expanding labels, expanded_ct.columns = %s != labeled_ct.rows %s" %
             (len(expanded_ct.columns), len(labeled_ct.columns)))
     disp.display(expanded_ct.head())
@@ -96,10 +104,15 @@ def data_quality_check(expanded_ct):
     '''1. Delete rows where the mode_confirm was pilot_ebike and repalced_mode was pilot_ebike.
        2. Delete rows where the mode_confirm was pilot_ebike and repalced_mode was same_mode.
        3. Replace same_mode for the mode_confirm for Energy Impact Calcualtion.'''
-    
-    expanded_ct.drop(expanded_ct[(expanded_ct['mode_confirm'] == 'pilot_ebike') & (expanded_ct['replaced_mode'] == 'pilot_ebike')].index, inplace=True)
-    expanded_ct.drop(expanded_ct[(expanded_ct['mode_confirm'] == 'pilot_ebike') & (expanded_ct['replaced_mode'] == 'same_mode')].index, inplace=True)
-    expanded_ct['replaced_mode'] = np.where(expanded_ct['replaced_mode'] == 'same_mode',expanded_ct['mode_confirm'], expanded_ct['replaced_mode'])
+
+    # TODO: This is only really required for the initial data collection around the minipilot
+    # in subsequent deployes, we removed "same mode" and "pilot_ebike" from the options, so the
+    # dataset did not contain of these data quality issues
+
+    if 'replaced_mode' in expanded_ct.columns:
+        expanded_ct.drop(expanded_ct[(expanded_ct['mode_confirm'] == 'pilot_ebike') & (expanded_ct['replaced_mode'] == 'pilot_ebike')].index, inplace=True)
+        expanded_ct.drop(expanded_ct[(expanded_ct['mode_confirm'] == 'pilot_ebike') & (expanded_ct['replaced_mode'] == 'same_mode')].index, inplace=True)
+        expanded_ct['replaced_mode'] = np.where(expanded_ct['replaced_mode'] == 'same_mode',expanded_ct['mode_confirm'], expanded_ct['replaced_mode'])
     
     return expanded_ct
 


### PR DESCRIPTION
- Change the mapping file:
    - change the mapping of `drove_alone` and `shared_ride` to "Gas Car"
    - change the mapping of `pilot_ebike` to `E-bike` since it won't always be part of a pilot
    - add mapping for `e-bike`, which is the new label for all e-bikes
    - add mapping for the new `E-car` entries

- Add new EI entries for the new e-car modes
    - e-car energy intensity is around 250WH/mile
        https://github.com/e-mission/e-mission-phone/commit/2cbcb8198e45ef6d426a3a3003d92fe2b065d262

- Changed the plots to have the new labels
    - Car -> Gas Car
    - Pilot e-bike -> E-bike
    - Add E-car entries

- Changed the data load in scaffolding
    - filter out non-test users from the metrics.
        - We initially used to have one server and mix testers and
          participants. So we had a function to only get participant trips for
          the metrics.
        - Then, we moved all the admins to a separate staging environment and
          only had participants in the actual enclaves. So we didn't need to
          filter by participants any more.
        - But now that we support customizations for programs, we need to have
          admins test out "their" configuration again. We do so by giving them
          "test" tokens for the production environment.
        - So we need to filter out these test tokens from the final metrics.
          Fortunately, we still had the original `get_participant_uuids`
          function, and just had to change the implementation.
    - check the number of added expanded columns based on the number of labels per trip
        - for a study, this would be 2
        - for a program, it would be 3
        - for a trip-level survey, it would be much more

Testing done:
- With these changes, and with the following changes to the `generic_metrics` notebook

```
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expanded_ct = scaffolding.expand_userinputs(labeled_ct)"
+    "expanded_ct = scaffolding.expand_userinputs(labeled_ct, 2)"
    ]
   },
   {
```

```
@@ -157,7 +167,17 @@
     "## Mapping new labels with dictionaries\n",
     "expanded_ct['Trip_purpose']= expanded_ct['purpose_confirm'].map(dic_pur)\n",
     "expanded_ct['Mode_confirm']= expanded_ct['mode_confirm'].map(dic_re)\n",
-    "expanded_ct['Replaced_mode']= expanded_ct['replaced_mode'].map(dic_re)"
+    "# expanded_ct['Replaced_mode']= expanded_ct['replaced_mode'].map(dic_re)"
+   ]
+  },
```

I can generate at least the basic mode share pie chart for the NREL commute dataset

This is a partial fix for
https://github.com/e-mission/e-mission-docs/issues/781