### PR TITLE
Address next error in codebuild

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,4 +4,4 @@ VOLUME /plots
 
 RUN mkdir -p /public
 COPY client /public/client
-COPY *.html /public
+COPY *.html /public/


### PR DESCRIPTION
```
Step 5/5 : COPY *.html /public
When using COPY with more than one source file, the destination must be a directory and end with a /
```