### PR TITLE
node used by http-server has vulnerabilities

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,14 @@
-FROM danjellz/http-server:1.4
-
+FROM node:18-alpine
 VOLUME /plots
 
 RUN mkdir -p /public
+WORKDIR /public
+
+RUN npm install -g npm@8.14.0 && npm i http-server
+
 COPY client /public/client
 COPY *.html /public/
+
+EXPOSE 8080
+CMD ["http-server"]
+


### PR DESCRIPTION
Switching to the standard node instead.

Since we are switching the base image, also copied over the other configurations from the Dockerfile at https://github.com/danjellesma/http-server/blob/master/Dockerfile

Note that we needed to set the WORKDIR *before* running `npm i http-server`, otherwise we get an error

```
 => ERROR [3/6] RUN npm i http-server                                                                    0.9s
------
 > [3/6] RUN npm i http-server:
```

Testing done: Builds

```
[+] Building 2.3s (12/12) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                         0.0s
 => => transferring dockerfile: 257B                                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/node:18-alpine                                                                                                            2.0s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                  0.0s
 => [1/6] FROM docker.io/library/node:18-alpine@sha256:ee2abfe3336a66f7976233633484609299dc906a553079a48aaae18200ebe369                                                      0.0s
 => [internal] load build context                                                                                                                                            0.1s
 => => transferring context: 1.76kB                                                                                                                                          0.0s
 => CACHED [2/6] RUN mkdir -p /public                                                                                                                                        0.0s
 => CACHED [3/6] WORKDIR /public                                                                                                                                             0.0s
 => CACHED [4/6] RUN npm install -g npm@8.14.0 && npm i http-server                                                                                                          0.0s
 => [5/6] COPY client /public/client                                                                                                                                         0.0s
 => [6/6] COPY *.html /public/                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                       0.1s
 => => exporting layers                                                                                                                                                      0.1s
 => => writing image sha256:7f0ab3d6bf511943763dc0efc7f7b664390ece4035c16fe94863a0f74db1f05c                                                                                 0.0s
 => => naming to docker.io/em-pub-dash-prod/frontend                                                                                                                         0.0s
```