### PR TITLE
Install the `http-server` module globally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - db
     ports:
       # DASH in numbers
-      - "3274:8080"
+      - "3274:5050"
     volumes:
       - ./plots:/public/plots
     networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,11 +4,11 @@ VOLUME /plots
 RUN mkdir -p /public
 WORKDIR /public
 
-RUN npm install -g npm@8.14.0 && npm i http-server
+RUN npm install -g npm@8.14.0 && npm i -g http-server
 
 COPY client /public/client
 COPY *.html /public/
 
-EXPOSE 8080
-CMD ["http-server"]
+EXPOSE 5050
+CMD ["http-server", "-p", "5050"]
 


### PR DESCRIPTION
So it can be run from the Dockerfile

Not quite sure when this behavior changed in node, since the original `http-server` docker repo https://github.com/danjellesma/http-server/blob/master/Dockerfile#L7 has `npm i` without the global flag and it works.

+ change port and docker-compose to allow it to run along with other containers

Testing done:
- Relying on similar change for the study join page