### PR TITLE
Handle retrieval of stage data better

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -346,14 +346,15 @@
              * easier to test against localhost
              */
             const _getStudyName = function(connectUrl) {
-              const orig_host = new URL(connectUrl).hostname;
-              // If we are running this on dev, use a param instead to enable testing
-              if (orig_host == "localhost") {
+              const _getFromParamOrDefault = function() {
                 const param_study_name = new URL(connectUrl).searchParams.get("study_config");
                 return param_study_name == null? "stage-program" : param_study_name;
               }
+              const orig_host = new URL(connectUrl).hostname;
+              // If we are running this on dev, use a param instead to enable testing
+              if (orig_host == "localhost") { return _getFromParamOrDefault(); }
               const first_domain = orig_host.split(".")[0];
-              if (first_domain == "openpath-stage") { return "stage"; }
+              if (first_domain == "openpath-stage") { return _getFromParamOrDefault(); }
               const openpath_index = first_domain.search("-openpath");
               if (openpath_index == -1) { return undefined; }
               const study_name = first_domain.substr(0,openpath_index);


### PR DESCRIPTION
We use the study name retrieved from the connect URL to retrieve the configuration from the server. For the stage environment, this study name is "stage". But there are separate stage study and program configurations. So we expand the hack to work with localhost to stage as well. In the hack, we put the config as a URL parameter and fall back to "stage-program" if it is not present.

Testing done:
- loaded localhost with and without the query parameter - with query parameter, loaded durham - without query parameter, loaded stage-program