### PR TITLE
Remove all references to the tests in conda packages

### DIFF
--- a/viz_scripts/Dockerfile
+++ b/viz_scripts/Dockerfile
@@ -22,6 +22,14 @@ COPY bin ./bin
 COPY *.ipynb .
 COPY *.py .
 
+# Delete all test packages since they generate false positives in the vulnerability scan
+# e.g.
+# root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/env_metadata/py27-osx-no-binary/lib/python2.7/site-packages/requests-2.19.1-py2.7.egg-info/PKG-INFO
+# root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/env_metadata/py36-osx-whl/lib/python3.6/site-packages/Django-2.1.dist-info/METADATA
+# root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/env_metadata/py36-osx-whl/lib/python3.6/site-packages/Scrapy-1.5.1.dist-info/METADATA
+
+RUN /bin/bash -c "find /root/miniconda-*/pkgs -wholename \*info/test\* -type d | xargs rm -rf"
+
 WORKDIR /usr/src/app
 
 ADD docker/start_notebook.sh /usr/src/app/start_notebook.sh


### PR DESCRIPTION
These were triggering the vulnerability scans - e.g

```
root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/env_metadata/py27-osx-no-binary/lib/python2.7/site-packages/requests-2.19.1-py2.7.egg-info/PKG-INFO
root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/env_metadata/py36-osx-whl/lib/python3.6/site-packages/Django-2.1.dist-info/METADATA
root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/env_metadata/py36-osx-whl/lib/python3.6/site-packages/Scrapy-1.5.1.dist-info/METADATA
```

Testing done:
- Before this change

```
$ find /root/miniconda-*/pkgs -wholename \*info/test\* -type d
...
/root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/env_metadata/pep345
/root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/conda_format_repo
/root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/conda_format_repo/noarch
/root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/conda_format_repo/osx-64
/root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/conda_format_repo/win-64
/root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/conda_format_repo/linux-64
...
/root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/data/conda_format_repo/win-32
/root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/conda_env/specs
/root/miniconda-4.12.0/pkgs/conda-4.12.0-py38h06a4308_0/info/test/tests/core
/root/miniconda-4.12.0/pkgs/libffi-3.4.2-h7f98852_5/info/test
/root/miniconda-4.12.0/pkgs/pandas-1.1.0-py37h3340039_0/info/test
/root/miniconda-4.12.0/pkgs/ld_impl_linux-64-2.36.1-hea4e1c9_2/info/test
/root/miniconda-4.12.0/pkgs/idna-3.3-pyhd3eb1b0_0/info/test
/root/miniconda-4.12.0/pkgs/libgfortran5-12.1.0-hdcd56e2_16/info/test
/root/miniconda-4.12.0/pkgs/ncurses-6.3-h27087fc_1/info/test
/root/miniconda-4.12.0/pkgs/pycosat-0.6.3-py38h7b6447c_1/info/test
/root/miniconda-4.12.0/pkgs/google-auth-1.20.1-py_0/info/test
/root/miniconda-4.12.0/pkgs/libgomp-12.1.0-h8d9b700_16/info/test
/root/miniconda-4.12.0/pkgs/conda-package-handling-1.8.1-py38h7f8727e_0/info/test
/root/miniconda-4.12.0/pkgs/conda-package-handling-1.8.1-py38h7f8727e_0/info/test/tests
...
/root/miniconda-4.12.0/pkgs/conda-package-handling-1.8.1-py38h7f8727e_0/info/test/tests/recipes
/root/miniconda-4.12.0/pkgs/conda-package-handling-1.8.1-py38h7f8727e_0/info/test/tests/recipes/cph_test_data
/root/miniconda-4.12.0/pkgs/pysocks-1.7.1-py37h89c1867_5/info/test
/root/miniconda-4.12.0/pkgs/brotlipy-0.7.0-py38h27cfd23_1003/info/test
/root/miniconda-4.12.0/pkgs/libffi-3.3-he6710b0_2/info/test
/root/miniconda-4.12.0/pkgs/pyopenssl-22.0.0-pyhd3eb1b0_0/info/test
/root/miniconda-4.12.0/pkgs/six-1.16.0-pyh6c4a22f_0/info/test
/root/miniconda-4.12.0/pkgs/pycparser-2.21-pyhd3eb1b0_0/info/test
/root/miniconda-4.12.0/pkgs/readline-8.1.2-h0f457ee_0/info/test
/root/miniconda-4.12.0/pkgs/zipp-3.8.1-pyhd8ed1ab_0/info/test
/root/miniconda-4.12.0/pkgs/attrdict-2.0.1-pyhd8ed1ab_1/info/test
/root/miniconda-4.12.0/pkgs/urllib3-1.26.8-pyhd3eb1b0_0/info/test
/root/miniconda-4.12.0/pkgs/colorama-0.4.4-pyhd3eb1b0_0/info/test
/root/miniconda-4.12.0/pkgs/cryptography-36.0.0-py38h9ce1e76_0/info/test
/root/miniconda-4.12.0/pkgs/cryptography-36.0.0-py38h9ce1e76_0/info/test/tests
/root/miniconda-4.12.0/pkgs/cryptography-36.0.0-py38h9ce1e76_0/info/test/tests/hypothesis
...
/root/miniconda-4.12.0/pkgs/cryptography-36.0.0-py38h9ce1e76_0/info/test/tests/hazmat/backends
/root/miniconda-4.12.0/pkgs/cryptography-36.0.0-py38h9ce1e76_0/info/test/tests/x509
/root/miniconda-4.12.0/pkgs/cffi-1.15.1-py37h43b0acd_0/info/test
/root/miniconda-4.12.0/pkgs/libgcc-ng-12.1.0-h8d9b700_16/info/test
/root/miniconda-4.12.0/pkgs/libzlib-1.2.12-h166bdaf_3/info/test
/root/miniconda-4.12.0/pkgs/numpy-1.19.1-py37h7ea13bd_2/info/test
/root/miniconda-4.12.0/pkgs/idna-2.10-pyh9f0ad1d_0/info/test
/root/miniconda-4.12.0/pkgs/requests-2.27.1-pyhd3eb1b0_0/info/test
/root/miniconda-4.12.0/pkgs/libstdcxx-ng-12.1.0-ha89aaad_16/info/test
/root/miniconda-4.12.0/pkgs/sqlite-3.39.3-h4ff8645_0/info/test
/root/miniconda-4.12.0/pkgs/cryptography-37.0.4-py37h38fbfac_0/info/test
/root/miniconda-4.12.0/pkgs/cryptography-37.0.4-py37h38fbfac_0/info/test/tests
/root/miniconda-4.12.0/pkgs/cryptography-37.0.4-py37h38fbfac_0/info/test/tests/hypothesis
/root/miniconda-4.12.0/pkgs/cryptography-37.0.4-py37h38fbfac_0/info/test/tests/bench
/root/miniconda-4.12.0/pkgs/mysql-common-8.0.30-haf5c9bc_1/info/test
...
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/test
/root/miniconda-4.12.0/pkgs/typing-extensions-4.3.0-hd8ed1ab_0/info/test
/root/miniconda-4.12.0/pkgs/jupyterlab_pygments-0.2.2-pyhd8ed1ab_0/info/test
/root/miniconda-4.12.0/pkgs/defusedxml-0.7.1-pyhd8ed1ab_0/info/test
/root/miniconda-4.12.0/pkgs/libwebp-base-1.2.4-h166bdaf_0/info/test
/root/miniconda-4.12.0/pkgs/qtconsole-base-5.3.2-pyha770c72_0/info/test
/root/miniconda-4.12.0/pkgs/backcall-0.2.0-pyh9f0ad1d_0/info/test
/root/miniconda-4.12.0/pkgs/krb5-1.19.3-h3790be6_0/info/test
/root/miniconda-4.12.0/pkgs/font-ttf-dejavu-sans-mono-2.37-hab24e00_0/info/test
```

- After this change

```
$ find /root/miniconda-*/pkgs -wholename \*info/test\* -type d
$ find /root/miniconda-*/pkgs -wholename \*info/test\*
$ find /root/miniconda-*/pkgs -wholename \*info\*
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/link.json
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/repodata_record.json
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/recipe
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/recipe/meta.yaml
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/recipe/conda_build_config.yaml
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/recipe/meta.yaml.template
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/hash_input.json
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/licenses
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/licenses/LICENSE
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/git
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/paths.json
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/files
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/index.json
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/info/about.json
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/site-packages/notebook/_sysinfo.py
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/site-packages/notebook-6.4.12.dist-info
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/site-packages/notebook-6.4.12.dist-info/INSTALLER
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/site-packages/notebook-6.4.12.dist-info/direct_url.json
/root/miniconda-4.12.0/pkgs/notebook-6.4.12-pyha770c72_0/site-packages/notebook-6.4.12.dist-info/entry_points.txt
```