### PR TITLE
Stop displaying backtraces in the case of an expected exception

### DIFF
--- a/viz_scripts/energy_calculations.ipynb
+++ b/viz_scripts/energy_calculations.ipynb
@@ -61,6 +61,8 @@
    "source": [
     "# Do not run this notebook at all unless it is for a program; nbclient will run up through this cell\n",
     "if study_type != \"program\":\n",
+    "    ipython = get_ipython()\n",
+    "    ipython._showtraceback = scaffolding.no_traceback_handler\n",
     "    raise Exception(\"The plots in this notebook are only relevant to programs\")"
    ]
   },

--- a/viz_scripts/mode_specific_metrics.ipynb
+++ b/viz_scripts/mode_specific_metrics.ipynb
@@ -61,6 +61,8 @@
    "source": [
     "# Do not run this notebook at all unless it is for a program; nbclient will run up through this cell\n",
     "if study_type != \"program\":\n",
+    "    ipython = get_ipython()\n",
+    "    ipython._showtraceback = scaffolding.no_traceback_handler\n",
     "    raise Exception(\"The plots in this notebook are only relevant to programs\")"
    ]
   },

--- a/viz_scripts/mode_specific_timeseries.ipynb
+++ b/viz_scripts/mode_specific_timeseries.ipynb
@@ -57,6 +57,8 @@
    "source": [
     "# Do not run this notebook at all unless it is for a program; nbclient will run up through this cell\n",
     "if study_type != \"program\":\n",
+    "    ipython = get_ipython()\n",
+    "    ipython._showtraceback = scaffolding.no_traceback_handler\n",
     "    raise Exception(\"The plots in this notebook are only relevant to programs\")"
    ]
   },

--- a/viz_scripts/scaffolding.py
+++ b/viz_scripts/scaffolding.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+import sys
 
 import emission.storage.timeseries.abstract_timeseries as esta
 import emission.storage.timeseries.tcquery as esttc
@@ -12,6 +13,9 @@ import emission.core.wrapper.localdate as ecwl
 import IPython.display as disp
 
 import emission.core.get_database as edb
+
+def no_traceback_handler(exception_type, exception, traceback):
+    print("%s: %s" % (exception_type.__name__, exception), file=sys.stderr)
 
 def get_time_query(year, month):
     if year is None and month is None:


### PR DESCRIPTION
This fixes the multiple ugly backtraces in the AWS logs https://github.com/e-mission/em-public-dashboard/issues/69#issuecomment-1257301755 and is based on https://pyquestions.com/how-do-i-suppress-tracebacks-in-jupyter