### PR TITLE
Store the saved_notebook in `.docker`

### DIFF
--- a/viz_scripts/Dockerfile
+++ b/viz_scripts/Dockerfile
@@ -32,11 +32,11 @@ RUN /bin/bash -c "find /root/miniconda-*/pkgs -wholename \*info/test\* -type d |
 
 WORKDIR /usr/src/app
 
-ADD docker/start_notebook.sh /usr/src/app/start_notebook.sh
-RUN chmod u+x /usr/src/app/start_notebook.sh
+ADD docker/start_notebook.sh /usr/src/app/.docker/start_notebook.sh
+RUN chmod u+x /usr/src/app/.docker/start_notebook.sh
 
 ADD docker/crontab /usr/src/app/crontab
 
 EXPOSE 8888
 
-CMD ["/bin/bash", "/usr/src/app/start_notebook.sh"]
+CMD ["/bin/bash", "/usr/src/app/.docker/start_notebook.sh"]

--- a/viz_scripts/docker/Dockerfile.dev
+++ b/viz_scripts/docker/Dockerfile.dev
@@ -14,11 +14,11 @@ WORKDIR /usr/src/app
 RUN /bin/bash -c "cd e-mission-server && source setup/activate.sh && conda env update --name emission --file setup/environment36.notebook.additions.yml"
 RUN /bin/bash -c "cd e-mission-server && source setup/activate.sh && conda env update --name emission --file /environment36.dashboard.additions.yml"
 
-ADD docker/start_notebook.sh /usr/src/app/start_notebook.sh
-RUN chmod u+x /usr/src/app/start_notebook.sh
+ADD docker/start_notebook.sh /usr/src/app/.docker/start_notebook.sh
+RUN chmod u+x /usr/src/app/.docker/start_notebook.sh
 
 ADD docker/crontab /usr/src/app/crontab
 
 EXPOSE 8888
 
-CMD ["/bin/bash", "/usr/src/app/start_notebook.sh"]
+CMD ["/bin/bash", "/usr/src/app/.docker/start_notebook.sh"]


### PR DESCRIPTION
Just like the other scheduled tasks

Testing done:
- Built the containers and ran the script

```
root@e51aa2d75fb0:/usr/src/app# bash .docker/start_notebook.sh
/usr/src/app/e-mission-server /usr/src/app
DB host = db
/usr/src/app
{
    "timeseries": {
        "url": "db",
        "result_limit": 100000
    }
}
Web host = 0.0.0.0
/usr/src/app/e-mission-server /usr/src/app
/usr/src/app/e-mission-server
base                     /root/miniconda-4.12.0
emission              *  /root/miniconda-4.12.0/envs/emission

/usr/src/app
Running crontab without user interaction, setting python path
```

All locations appear to be fixed

```
viz_scripts//docker/Dockerfile.dev:ADD docker/start_notebook.sh /usr/src/app/.docker/start_notebook.sh
viz_scripts//docker/Dockerfile.dev:RUN chmod u+x /usr/src/app/.docker/start_notebook.sh
viz_scripts//docker/Dockerfile.dev:CMD ["/bin/bash", "/usr/src/app/.docker/start_notebook.sh"]
viz_scripts//Dockerfile:ADD docker/start_notebook.sh /usr/src/app/.docker/start_notebook.sh
viz_scripts//Dockerfile:RUN chmod u+x /usr/src/app/.docker/start_notebook.sh
viz_scripts//Dockerfile:CMD ["/bin/bash", "/usr/src/app/.docker/start_notebook.sh"]
```