### PR TITLE
:lock: implement a basic CSP so that we can pass the WAVA scan

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta http-equiv="Content-Security-Policy" content="base-uri 'self'; default-src 'self' 'unsafe-inline' data: https://raw.githubusercontent.com https://stackpath.bootstrapcdn.com https://fonts.googleapis.com/ https://fonts.gstatic.com https://code.jquery.com https://kit.fontawesome.com https://ka-f.fontawesome.com;">
 		<title>Placeholder</title>
 
 		<!-- == APPLICATION HEAD == -->


### PR DESCRIPTION
The CSP has multiple limitations:
- uses `unsafe-inline` - I tried the nonce and it didn't work
- puts everything into `default-src`
- still has issues with the loading of some google fonts

Filed issue to have the template fixed
https://github.com/NREL/nrel-app-template-bootstrap4/issues/16