### PR TITLE
✨ Add support for displaying sensor-based metrics to the public dashb…

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -381,8 +381,10 @@
                                 addPreconfiguredMetrics([
                                     "ntrips_mode_confirm",
                                     "miles_mode_confirm",
+                                    "ntrips_sensed_mode",
+                                    "miles_sensed_mode",
                                     `ntrips_${data.intro.mode_studied}_purpose`,
-                                    `ntrips_${data.intro.mode_studied}_per_day`,
+                                    `ntrips_${data.intro.mode_studied}_per_weekday`,
                                     `sketch_CO2impact_${data.intro.mode_studied}`
                                 ]);
                             });
@@ -391,8 +393,10 @@
                             addPreconfiguredMetrics([
                                 "ntrips_mode_confirm",
                                 "miles_mode_confirm",
+                                "ntrips_sensed_mode",
+                                "miles_sensed_mode",
                                 "ntrips_purpose",
-                                "ntrips_per_weekday",
+                                "ntrips_sensed_per_weekday",
                                 "ts_emissions_user"
                             ]);
 						};

--- a/frontend/metrics_program.html
+++ b/frontend/metrics_program.html
@@ -1,13 +1,20 @@
 <!-- Generic -->
 <option value="ntrips_mode_confirm" data-sizex="4" data-sizey="4">Number of trips</option>
 <option value="ntrips_commute_mode_confirm" data-sizex="4" data-sizey="4">Number of commute trips</option>
+<option value="ntrips_sensed_mode" data-sizex="4" data-sizey="4">Number of trips (sensed)</option>
 <option value="ntrips_purpose" data-sizex="4" data-sizey="4">Trip count by purpose</option>
 <option value="ntrips_under10miles_mode_confirm" data-sizex="4" data-sizey="4">Trip count under 10 miles</option>
+<option value="ntrips_under10miles_sensed_mode" data-sizex="4" data-sizey="4">Trip count under 10 miles (sensed)</option>
 <option value="miles_mode_confirm" data-sizex="4" data-sizey="4">Trip miles by mode</option>
+<option value="miles_sensed_mode" data-sizex="4" data-sizey="4">Trip miles by mode</option>
+<option value="miles_sensed_mode_land" data-sizex="4" data-sizey="4">Trip miles by land mode (sensed)</option>
 <option value="average_miles_mode_confirm" data-sizex="6" data-sizey="4">Average trip length</option>
+<option value="average_miles_sensed_mode" data-sizex="6" data-sizey="4">Average trip length (sensed)</option>
 <option value="average_miles_mode_confirm2" data-sizex="6" data-sizey="4">Average trip length (selected by users)</option>
 <option value="ntrips_per_day" data-sizex="6" data-sizey="4">Trip frequency</option>
+<option value="ntrips_sensed_per_day" data-sizex="6" data-sizey="4">Trip frequency (sensed)</option>
 <option value="ntrips_per_weekday" data-sizex="6" data-sizey="4">Trip frequency (weekday)</option>
+<option value="ntrips_sensed_per_weekday" data-sizex="6" data-sizey="4">Trip frequency (weekday, sensed)</option>
 <option value="ts_emissions_user" data-sizex="8" data-sizey="2">Timeseries of emissions</option>
 <option value="ts_energy_user" data-sizex="8" data-sizey="2">Timeseries of energy</option>
 <option value="ts_emissions_vmt" data-sizex="8" data-sizey="2">Timeseries of emissions per mile</option>

--- a/frontend/metrics_study.html
+++ b/frontend/metrics_study.html
@@ -1,13 +1,20 @@
 <!-- Generic -->
 <option value="ntrips_mode_confirm" data-sizex="4" data-sizey="4">Number of trips</option>
 <option value="ntrips_commute_mode_confirm" data-sizex="4" data-sizey="4">Number of commute trips</option>
+<option value="ntrips_sensed_mode" data-sizex="4" data-sizey="4">Number of trips (sensed)</option>
 <option value="ntrips_purpose" data-sizex="4" data-sizey="4">Trip count by purpose</option>
 <option value="ntrips_under10miles_mode_confirm" data-sizex="4" data-sizey="4">Trip count under 10 miles</option>
+<option value="ntrips_under10miles_sensed_mode" data-sizex="4" data-sizey="4">Trip count under 10 miles (sensed)</option>
 <option value="miles_mode_confirm" data-sizex="4" data-sizey="4">Trip miles by mode</option>
+<option value="miles_sensed_mode" data-sizex="4" data-sizey="4">Trip miles by mode (sensed)</option>
+<option value="miles_sensed_mode_land" data-sizex="4" data-sizey="4">Trip miles by land mode (sensed)</option>
 <option value="average_miles_mode_confirm" data-sizex="6" data-sizey="4">Average trip length</option>
+<option value="average_miles_sensed_mode" data-sizex="6" data-sizey="4">Average trip length (sensed)</option>
 <option value="average_miles_mode_confirm2" data-sizex="6" data-sizey="4">Average trip length (selected by users)</option>
 <option value="ntrips_per_day" data-sizex="6" data-sizey="4">Trip frequency</option>
+<option value="ntrips_sensed_per_day" data-sizex="6" data-sizey="4">Trip frequency (sensed)</option>
 <option value="ntrips_per_weekday" data-sizex="6" data-sizey="4">Trip frequency (weekday)</option>
+<option value="ntrips_sensed_per_weekday" data-sizex="6" data-sizey="4">Trip frequency (weekday, sensed)</option>
 <option value="ts_emissions_user" data-sizex="8" data-sizey="2">Timeseries of emissions</option>
 <option value="ts_energy_user" data-sizex="8" data-sizey="2">Timeseries of energy</option>
 <option value="ts_emissions_vmt" data-sizex="8" data-sizey="2">Timeseries of emissions per mile</option>

--- a/viz_scripts/Dockerfile
+++ b/viz_scripts/Dockerfile
@@ -1,5 +1,5 @@
 # python 3
-FROM shankari/e-mission-server:gis-based-mode-detection_2023-07-12--58-55
+FROM shankari/e-mission-server:gis-based-mode-detection_2023-08-27--25-01
 
 VOLUME /plots
 

--- a/viz_scripts/bin/generate_plots.py
+++ b/viz_scripts/bin/generate_plots.py
@@ -69,7 +69,8 @@ def compute_for_date(month, year):
         program=args.program,
         study_type=dynamic_config['intro']['program_or_study'],
         mode_of_interest=mode_studied,
-        include_test_users=dynamic_config.get('metrics', {}).get('include_test_users', False))
+        include_test_users=dynamic_config.get('metrics', {}).get('include_test_users', False),
+        sensed_algo_prefix=dynamic_config.get('metrics', {}).get('sensed_algo_prefix', "cleaned"))
 
     print(f"Running at {arrow.get()} with params {params}")
 

--- a/viz_scripts/docker/Dockerfile.dev
+++ b/viz_scripts/docker/Dockerfile.dev
@@ -1,5 +1,5 @@
 # python 3
-FROM shankari/e-mission-server:gis-based-mode-detection_2023-07-12--58-55
+FROM shankari/e-mission-server:gis-based-mode-detection_2023-08-27--25-01
 
 VOLUME /plots
 

--- a/viz_scripts/docker/crontab
+++ b/viz_scripts/docker/crontab
@@ -1,5 +1,6 @@
 0 7 * * * python bin/update_mappings.py mapping_dictionaries.ipynb >> /var/log/intake.stdinout 2>&1
 0 8 * * * python bin/generate_plots.py generic_metrics.ipynb default >> /var/log/intake.stdinout 2>&1
+0 8 * * * python bin/generate_plots.py generic_metrics_sensed.ipynb default >> /var/log/intake.stdinout 2>&1
 0 8 * * * python bin/generate_plots.py generic_timeseries.ipynb default >> /var/log/intake.stdinout 2>&1
 0 8 * * * python bin/generate_plots.py mode_specific_metrics.ipynb default >> /var/log/intake.stdinout 2>&1
 0 8 * * * python bin/generate_plots.py mode_specific_timeseries.ipynb default >> /var/log/intake.stdinout 2>&1

--- a/viz_scripts/generic_metrics_sensed.ipynb
+++ b/viz_scripts/generic_metrics_sensed.ipynb
@@ -258,7 +258,7 @@
    "outputs": [],
    "source": [
     "plot_title_no_quality=\"Number of trips by day\\n(inferred by OpenPATH from phone sensors)\"\n",
-    "file_name ='ntrips_per_day%s' % file_suffix\n",
+    "file_name ='ntrips_sensed_per_day%s' % file_suffix\n",
     "\n",
     "try:\n",
     "    fq_days = expanded_ct.groupby(['start_local_dt_day']).agg({'start_local_dt_day': ['sum', 'count']})\n",
@@ -294,7 +294,7 @@
    "outputs": [],
    "source": [
     "plot_title_no_quality=\"Number of trips by weekday\\n(inferred by OpenPATH from phone sensors)\"\n",
-    "file_name ='ntrips_per_weekday%s' % file_suffix\n",
+    "file_name ='ntrips_sensed_per_weekday%s' % file_suffix\n",
     "try:\n",
     "    fq_weekdays = expanded_ct.groupby(['start_local_dt_weekday']).agg({'start_local_dt_weekday': ['sum', 'count']})\n",
     "    fq_weekdays = fq_weekdays.reset_index()\n",

--- a/viz_scripts/generic_metrics_sensed.ipynb
+++ b/viz_scripts/generic_metrics_sensed.ipynb
@@ -1,0 +1,348 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "academic-context",
+   "metadata": {},
+   "source": [
+    "## Generate Static Graphs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "medium-siemens",
+   "metadata": {},
+   "source": [
+    "These are the input parameters for the notebook. They will be automatically changed when the scripts to generate monthly statistics are run. You can modify them manually to generate multiple plots locally as well.\n",
+    "\n",
+    "Pass in `None` to remove the filters and plot all data. This is not recommended for production settings, but might be useful for reports based on data snapshots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "narrative-hunter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "year = 2020\n",
+    "month = 11\n",
+    "program = \"default\"\n",
+    "study_type = \"study\"\n",
+    "mode_of_interest = None\n",
+    "include_test_users = False\n",
+    "sensed_algo_prefix = \"cleaned\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "activated-portugal",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import defaultdict\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from plots import *\n",
+    "import scaffolding\n",
+    "\n",
+    "sns.set_style(\"whitegrid\")\n",
+    "sns.set()\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intellectual-columbus",
+   "metadata": {},
+   "source": [
+    "## Collect Data From Database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "organic-pitch",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expanded_ct, file_suffix, quality_text, debug_df = scaffolding.load_viz_notebook_sensor_inference_data(year,\n",
+    "                                                                            month,\n",
+    "                                                                            program,\n",
+    "                                                                            include_test_users,\n",
+    "                                                                            sensed_algo_prefix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "modified-skiing",
+   "metadata": {},
+   "source": [
+    "## Generic Metrics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "distributed-peace",
+   "metadata": {},
+   "source": [
+    "### Distribution of Mode_confirm attribute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tracked-serbia",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "file_name='ntrips_sensed_mode%s' % file_suffix\n",
+    "plot_title_no_quality= \"Number of trips for each primary mode\\n(inferred by OpenPATH from phone sensors)\"\n",
+    "try:\n",
+    "    labels_mc = expanded_ct['primary_mode'].value_counts(dropna=True).keys().tolist()\n",
+    "    values_mc = expanded_ct['primary_mode'].value_counts(dropna=True).tolist()    \n",
+    "    plot_title = plot_title_no_quality+\"\\n\"+quality_text\n",
+    "    pie_chart_sensed_mode(plot_title,labels_mc,values_mc,file_name)\n",
+    "    alt_text = store_alt_text_pie(pd.DataFrame(values_mc, labels_mc), file_name, plot_title)\n",
+    "    print(expanded_ct['primary_mode'].value_counts(dropna=True))\n",
+    "except Exception as e:\n",
+    "    logging.exception(e)\n",
+    "    generate_missing_plot(plot_title_no_quality,debug_df,file_name)\n",
+    "    alt_text = store_alt_text_missing(debug_df, file_name, plot_title_no_quality)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "crucial-keyboard",
+   "metadata": {},
+   "source": [
+    "### Mode choice for trips under 10 miles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "identified-replica",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_title_no_quality=\"Number of trips under 10 Miles for each primary mode\\n(inferred by OpenPATH from phone sensors)\"\n",
+    "file_name ='ntrips_under10miles_sensed_mode%s' % file_suffix\n",
+    "try:\n",
+    "    labels_d10 = expanded_ct.loc[(expanded_ct['distance_miles'] <= 10)].primary_mode.value_counts(dropna=True).keys().tolist()\n",
+    "    values_d10 = expanded_ct.loc[(expanded_ct['distance_miles'] <= 10)].primary_mode.value_counts(dropna=True).tolist()\n",
+    "    d10_quality_text = scaffolding.get_quality_text(expanded_ct, expanded_ct[expanded_ct['distance_miles'] <= 10], \"< 10 mile\", include_test_users)\n",
+    "    plot_title= plot_title_no_quality+\"\\n\"+d10_quality_text\n",
+    "    pie_chart_sensed_mode(plot_title,labels_d10,values_d10,file_name)\n",
+    "    alt_text = store_alt_text_pie(pd.DataFrame(values_d10, labels_d10), file_name, plot_title)\n",
+    "    print(expanded_ct.loc[(expanded_ct['distance_miles'] <= 10)].primary_mode.value_counts(dropna=True))\n",
+    "except Exception as e:\n",
+    "    logging.exception(e)\n",
+    "    d10_df = expanded_ct.query(\"distance_miles <= 10\") if \"distance_miles\" in expanded_ct.columns else expanded_ct\n",
+    "    debug_df.loc[\"Trips_less_than_10_miles\"] = scaffolding.trip_label_count(\"Mode_confirm\", d10_df)\n",
+    "    generate_missing_plot(plot_title_no_quality,debug_df,file_name)\n",
+    "    alt_text = store_alt_text_missing(debug_df, file_name, plot_title_no_quality)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dominant-company",
+   "metadata": {},
+   "source": [
+    "### Miles per chosen transport mode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "satisfied-sharing",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_title_no_quality=\"Miles for each primary mode\\n(inferred by OpenPATH from phone sensors)\"\n",
+    "file_name ='miles_sensed_mode%s' % file_suffix\n",
+    "\n",
+    "try:\n",
+    "    miles = expanded_ct.groupby('primary_mode').agg({'distance_miles': ['sum', 'count' , 'mean']})\n",
+    "    miles.columns = ['Total (miles)', 'Count', 'Average (miles)']\n",
+    "    miles = miles.reset_index()\n",
+    "    miles =miles.sort_values(by=['Total (miles)'], ascending=False)\n",
+    "\n",
+    "    #data\n",
+    "    miles_dict = dict(zip(miles['primary_mode'], miles['Total (miles)']))\n",
+    "\n",
+    "    labels_m = []\n",
+    "    values_m = []\n",
+    "\n",
+    "    for x, y in miles_dict.items():\n",
+    "        labels_m.append(x)\n",
+    "        values_m.append(y)\n",
+    "        \n",
+    "    plot_title=\"Miles for each mode\\n(inferred by OpenPATH from phone sensors)\\n%s\" % quality_text\n",
+    "\n",
+    "    pie_chart_sensed_mode(plot_title,labels_m,values_m,file_name)\n",
+    "    alt_text = store_alt_text_pie(pd.DataFrame(values_m, labels_m), file_name, plot_title)\n",
+    "    print(miles)\n",
+    "except:\n",
+    "    generate_missing_plot(plot_title_no_quality,debug_df,file_name)\n",
+    "    alt_text = store_alt_text_missing(debug_df, file_name, plot_title_no_quality)    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d0c7548",
+   "metadata": {},
+   "source": [
+    "### Miles per chosen land transport mode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "004b7b3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_title_no_quality=\"Miles for each land-based primary mode\\n(inferred by OpenPATH from phone sensors)\"\n",
+    "file_name ='miles_sensed_mode_land%s' % file_suffix\n",
+    "\n",
+    "try:\n",
+    "    miles = expanded_ct.groupby('primary_mode').agg({'distance_miles': ['sum', 'count' , 'mean']})\n",
+    "    miles.columns = ['Total (miles)', 'Count', 'Average (miles)']\n",
+    "    miles = miles.reset_index()\n",
+    "    miles =miles.sort_values(by=['Total (miles)'], ascending=False)\n",
+    "\n",
+    "    #data\n",
+    "    miles_dict = dict(zip(miles['primary_mode'], miles['Total (miles)']))\n",
+    "\n",
+    "    labels_m = []\n",
+    "    values_m = []\n",
+    "\n",
+    "    for x, y in miles_dict.items():\n",
+    "        if x != \"AIR_OR_HSR\":\n",
+    "            labels_m.append(x)\n",
+    "            values_m.append(y)\n",
+    "        \n",
+    "    plot_title=\"Miles for each land-based mode\\n(inferred by OpenPATH from phone sensors)\\n%s\" % quality_text\n",
+    "\n",
+    "    pie_chart_sensed_mode(plot_title,labels_m,values_m,file_name)\n",
+    "    alt_text = store_alt_text_pie(pd.DataFrame(values_m, labels_m), file_name, plot_title)\n",
+    "    print(miles)\n",
+    "except:\n",
+    "    generate_missing_plot(plot_title_no_quality,debug_df,file_name)\n",
+    "    alt_text = store_alt_text_missing(debug_df, file_name, plot_title_no_quality)    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "130100ee",
+   "metadata": {},
+   "source": [
+    "### Number of trips by day¶"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9933d138",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_title_no_quality=\"Number of trips by day\\n(inferred by OpenPATH from phone sensors)\"\n",
+    "file_name ='ntrips_per_day%s' % file_suffix\n",
+    "\n",
+    "try:\n",
+    "    fq_days = expanded_ct.groupby(['start_local_dt_day']).agg({'start_local_dt_day': ['sum', 'count']})\n",
+    "    fq_days = fq_days.reset_index()\n",
+    "    fq_days.columns = ['Day of the Month', 'Total', 'Number of Trips']\n",
+    "\n",
+    "    data = fq_days\n",
+    "    x = 'Day of the Month'\n",
+    "    y = 'Number of Trips'\n",
+    "    \n",
+    "    plot_title= plot_title_no_quality+\"\\n\"+quality_text\n",
+    "\n",
+    "    barplot_day(data,x,y,plot_title,file_name)\n",
+    "    alt_text = store_alt_text_bar(pd.DataFrame(data['Number of Trips'].values, data['Day of the Month']), file_name, plot_title)\n",
+    "except:\n",
+    "    generate_missing_plot(plot_title_no_quality,debug_df,file_name)\n",
+    "    alt_text = store_alt_text_missing(debug_df, file_name, plot_title_no_quality)    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be9479ad",
+   "metadata": {},
+   "source": [
+    "### Number of trips by day of week¶"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9878ceaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_title_no_quality=\"Number of trips by weekday\\n(inferred by OpenPATH from phone sensors)\"\n",
+    "file_name ='ntrips_per_weekday%s' % file_suffix\n",
+    "try:\n",
+    "    fq_weekdays = expanded_ct.groupby(['start_local_dt_weekday']).agg({'start_local_dt_weekday': ['sum', 'count']})\n",
+    "    fq_weekdays = fq_weekdays.reset_index()\n",
+    "    fq_weekdays.columns = ['Weekday', 'Total', 'Number of Trips']\n",
+    "    weekday_labels = [\"Mon\", \"Tue\", \"Wed\", \"Thu\", \"Fri\", \"Sat\", \"Sun\"]\n",
+    "    fq_weekdays[\"Weekday\"] = fq_weekdays.Weekday.apply(lambda x: weekday_labels[x])\n",
+    "\n",
+    "    data = fq_weekdays\n",
+    "    x = 'Weekday'\n",
+    "    y = 'Number of Trips'\n",
+    "\n",
+    "    plot_title= plot_title_no_quality+\"\\n\"+quality_text\n",
+    "    \n",
+    "    barplot_day(data,x,y,plot_title,file_name)\n",
+    "    alt_text = store_alt_text_bar(pd.DataFrame(data['Number of Trips'].values, data['Weekday']), file_name, plot_title)\n",
+    "except:\n",
+    "    generate_missing_plot(plot_title_no_quality,debug_df,file_name)\n",
+    "    alt_text = store_alt_text_missing(debug_df, file_name, plot_title_no_quality)    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a32859f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/viz_scripts/plots.py
+++ b/viz_scripts/plots.py
@@ -50,6 +50,13 @@ def merge_small_entries(labels, values):
 
     return (v2l_df.index.to_list(),v2l_df.vals.to_list())
 
+
+def format_pct(pct, values):
+    total = sum(values)
+    absolute = int(round(pct*total/100.0))
+    return "{:.1f}%\n({:d})".format(pct, absolute) if pct > 4 else''
+
+
 def pie_chart_mode(plot_title,labels,values,file_name):
     all_labels= ['Gas Car, drove alone',
                  'Bus', 
@@ -78,16 +85,39 @@ def pie_chart_mode(plot_title,labels,values,file_name):
 
     m_labels, m_values = merge_small_entries(labels, values)
     
-    def func(pct, values):
-        total = sum(values)
-        absolute = int(round(pct*total/100.0))
-        return "{:.1f}%\n({:d})".format(pct, absolute) if pct > 4 else''
- 
     wedges, texts, autotexts = ax.pie(m_values,
                                       labels = m_labels,
                                       colors=[colours[key] for key in labels],
                                       pctdistance=0.75,
-                                      autopct= lambda pct: func(pct, values),
+                                      autopct= lambda pct: format_pct(pct, values),
+                                      textprops={'size': 23})
+
+    ax.set_title(plot_title, size=25)
+    plt.text(-1.3,-1.3,f"Last updated {arrow.get()}", fontsize=10)
+    plt.setp(autotexts, **{'color':'white', 'weight':'bold', 'fontsize':20})
+    plt.savefig(SAVE_DIR+file_name+".png", bbox_inches='tight')
+    plt.show()
+
+def pie_chart_sensed_mode(plot_title,labels,values,file_name):
+    all_labels= ['IN_VEHICLE',
+                 'UNKNOWN',
+                 'WALKING',
+                 'AIR_OR_HSR',
+                 'BICYCLING',
+                 'OTHER']
+
+    val2labeldf = pd.DataFrame({"labels": labels, "values": values})
+
+    colours = dict(zip(all_labels, plt.cm.tab10.colors[:len(all_labels)]))
+    fig, ax = plt.subplots(figsize=(10, 10), subplot_kw=dict(aspect="equal"))
+
+    m_labels, m_values = merge_small_entries(labels, values)
+
+    wedges, texts, autotexts = ax.pie(m_values,
+                                      labels = m_labels,
+                                      colors=[colours[key] for key in labels],
+                                      pctdistance=0.75,
+                                      autopct= lambda pct: format_pct(pct, values),
                                       textprops={'size': 23})
 
     ax.set_title(plot_title, size=25)

--- a/viz_scripts/scaffolding.py
+++ b/viz_scripts/scaffolding.py
@@ -110,7 +110,7 @@ def load_viz_notebook_data(year, month, program, study_type, dic_re, dic_pur=Non
     """ Inputs:
     year/month/program/study_type = parameters from the visualization notebook
     dic_* = label mappings; if dic_pur is included it will be used to recode trip purpose
-    
+
     Pipeline to load and process the data before use in visualization notebooks.
     """
     # Access database
@@ -161,6 +161,40 @@ def load_viz_notebook_data(year, month, program, study_type, dic_re, dic_pur=Non
 
     return expanded_ct, file_suffix, quality_text, debug_df
 
+def load_viz_notebook_sensor_inference_data(year, month, program, include_test_users=False, sensed_algo_prefix="cleaned"):
+    """ Inputs:
+    year/month/program = parameters from the visualization notebook
+
+    Pipeline to load and process the data before use in sensor-based visualization notebooks.
+    """
+    tq = get_time_query(year, month)
+    participant_ct_df = load_all_participant_trips(program, tq, include_test_users)
+    expanded_ct = participant_ct_df
+    expanded_ct["primary_mode_non_other"] = participant_ct_df.cleaned_section_summary.apply(lambda md: max(md["distance"], key=md["distance"].get))
+    expanded_ct.primary_mode_non_other.replace({"ON_FOOT": "WALKING"}, inplace=True)
+    valid_sensed_modes = ["WALKING", "BICYCLING", "IN_VEHICLE", "AIR_OR_HSR", "UNKNOWN"]
+    expanded_ct["primary_mode"] = expanded_ct.primary_mode_non_other.apply(lambda pm: "OTHER" if pm not in valid_sensed_modes else pm)
+
+    # Change meters to miles
+    # CASE 2 of https://github.com/e-mission/em-public-dashboard/issues/69#issuecomment-1256835867
+    if "distance" in expanded_ct.columns:
+        unit_conversions(expanded_ct)
+
+    # Document data quality
+    file_suffix = get_file_suffix(year, month, program)
+    quality_text = get_quality_text_sensed(expanded_ct, include_test_users)
+
+    debug_df = pd.DataFrame.from_dict({
+            "year": year,
+            "month": month,
+            "Registered_participants": len(get_participant_uuids(program, include_test_users)),
+            "Participants_with_at_least_one_trip": unique_users(participant_ct_df),
+            "Number of trips": len(participant_ct_df),
+            },
+        orient='index', columns=["value"])
+
+    return expanded_ct, file_suffix, quality_text, debug_df
+
 def add_energy_labels(expanded_ct, df_ei, dic_fuel):
     """ Inputs:
     expanded_ct = dataframe of trips that has had Mode_confirm and Replaced_mode added
@@ -197,6 +231,13 @@ def get_quality_text(before_df, after_df, mode_of_interest=None, include_test_us
     total_str = 'confirmed' if mode_of_interest is not None else ''
     user_str = 'testers and participants' if include_test_users else 'users'
     quality_text = f"Based on %s confirmed {interest_str}trips from %d {user_str}\nof %s total {total_str} trips from %d users (%.2f%%)" % cq
+    print(quality_text)
+    return quality_text
+
+def get_quality_text_sensed(df, include_test_users=False):
+    cq = (len(df), unique_users(df))
+    user_str = 'testers and participants' if include_test_users else 'users'
+    quality_text = f"Based on %s trips from %d {user_str}" % cq
     print(quality_text)
     return quality_text
 


### PR DESCRIPTION
…oard

- Add a new method to read the data and fill in the primary mode based on the `sensed_algo_prefix`
- Add a new method to get the quality text which clarifies that it is inferred by OpenPATH but uses all the data
- Add a new method to plot `sensed_mode` pie charts, which is a duplicate of the existing `pie_chart_mode`, but with a different set of labels - Refactor `pie_chart_mode` to pull out the `func` and rename it `format_pct` so that we can reuse it in both functions
- Change `generate_plots` to read in the `sensed_algo_prefix` from the config and pass it in to the notebooks - with a default of `cleaned` since none of the configs have this prefix defined yet

This is the bulk of the heavy lifting.

Remaining commits are:
- creating a notebook that uses it
- running the notebook automatically
- adding the new metrics to the frontend