### PR TITLE
fix error on older configs that don't have survey_info

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -430,10 +430,10 @@
           mode_studied = data.intro.mode_studied
           // Load list of plots corresponding to study/program
           dynamic_labels = data.label_options
-          surveys = data.survey_info.surveys 
           sheet_list = []
-          console.log(data.survey_info['trip-labels'])
-          if (data.survey_info['trip-labels'] === 'ENKETO') { //CASE: SURVEYS
+          console.log(data.survey_info?.['trip-labels'])
+          if (data.survey_info?.['trip-labels'] === 'ENKETO') { //CASE: SURVEYS
+            surveys = data.survey_info.surveys
             survey_list = Object.keys(surveys)
             survey_list = survey_list.filter(name => name !== 'UserProfileSurvey')
 


### PR DESCRIPTION
The survey_info field is not present on configs older than approx. late 2022 / early 2023. This caused an error on the public dashboard webpage which prevented the dropdown menus from populating or any charts from showing. Observed on smart-commute-ebike in production.

This fix considers that survey_info might not be present and and only proceeds if it is. Tested locally with the smart-commute-ebike config and observed that the error goes away when the fix is applied