### PR TITLE
Updated Labeled and Inferred Stacked Bars

### DIFF
--- a/viz_scripts/scaffolding.py
+++ b/viz_scripts/scaffolding.py
@@ -161,15 +161,14 @@ def expand_inferredlabels(labeled_inferred_ct):
         if row['user_input']:
             return row['user_input']
         max_entry = max(row['inferred_labels'], key=lambda x: x['p'])
-        return max_entry['labels'] if max_entry['p'] > row['confidence_threshold'] else {
-            'mode_confirm': 'uncertain'
-        }
+        # Look up for the 'p' value > 90%
+        return max_entry['labels'] if (max_entry['p'] > .90) else {}
 
     labeled_inferred_labels = labeled_inferred_ct.apply(_select_max_label, axis=1).apply(pd.Series)
     disp.display(labeled_inferred_labels.head())
     expanded_labeled_inferred_ct = pd.concat([labeled_inferred_ct, labeled_inferred_labels], axis=1)
-    # Filter out the dataframe in which mode_confirm is uncertain
-    expanded_labeled_inferred_ct = expanded_labeled_inferred_ct[(expanded_labeled_inferred_ct['mode_confirm'] != 'uncertain')]
+    # Filter out the dataframe
+    expanded_labeled_inferred_ct.dropna('index', how='all', inplace=True)
     disp.display(expanded_labeled_inferred_ct.head())
     return expanded_labeled_inferred_ct
 


### PR DESCRIPTION
- Use 90% confidence threshold. 
- Filter the expanded_labeled_inferred_ct with dropna.

Dataset used: `cortezebikes`


<details><summary>Execution of generic_metrics and mode_specific_metrics notebooks:</summary>
<p>

```
(emission) root@c594f330cf4b:/usr/src/app/saved-notebooks# PYTHONPATH=.. python bin/generate_plots.py generic_metrics.ipynb default
/usr/src/app/saved-notebooks/bin/generate_plots.py:30: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if r.status_code is not 200:
About to download config from https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/configs/cortezebikes.nrel-op.json
Successfully downloaded config with version 1 for Cortez 55+ eBike Program and data collection URL https://cortezebikes-openpath.nrel.gov/api/
label_options is unavailable for the dynamic_config in cortezebikes
Running at 2024-09-27T23:26:02.253056+00:00 with args Namespace(plot_notebook='generic_metrics.ipynb', program='default', date=None) for range (<Arrow [2023-06-01T00:00:00+00:00]>, <Arrow [2024-09-01T00:00:00+00:00]>)
Running at 2024-09-27T23:26:02.292094+00:00 with params [Parameter('year', int), Parameter('month', int), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:26:12.336503+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=6), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:26:19.247855+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=7), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:26:26.673323+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=8), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:26:34.142805+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=9), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:26:41.547290+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=10), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:26:48.919050+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=11), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:26:55.728161+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=12), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:27:02.584975+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=1), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:27:08.826527+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=2), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:27:15.142468+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=3), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:27:20.671427+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=4), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:27:26.239837+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=5), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:27:31.752795+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=6), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:27:37.203197+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=7), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:27:42.537367+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=8), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-27T23:27:47.890907+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=9), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
(emission) root@c594f330cf4b:/usr/src/app/saved-notebooks# PYTHONPATH=.. python bin/generate_plots.py mode_specific_metrics.ipynb default
/usr/src/app/saved-notebooks/bin/generate_plots.py:30: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if r.status_code is not 200:
About to download config from https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/configs/cortezebikes.nrel-op.json
Successfully downloaded config with version 1 for Cortez 55+ eBike Program and data collection URL https://cortezebikes-openpath.nrel.gov/api/
label_options is unavailable for the dynamic_config in cortezebikes
Running at 2024-09-27T23:28:07.889129+00:00 with args Namespace(plot_notebook='mode_specific_metrics.ipynb', program='default', date=None) for range (<Arrow [2023-06-01T00:00:00+00:00]>, <Arrow [2024-09-01T00:00:00+00:00]>)
Running at 2024-09-27T23:28:07.928316+00:00 with params [Parameter('year', int), Parameter('month', int), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:28:15.138443+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=6), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:28:20.601037+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=7), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:28:25.889084+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=8), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:28:31.241631+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=9), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:28:36.852092+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=10), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:28:42.206773+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=11), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:28:47.024394+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=12), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:28:51.313112+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=1), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:28:56.380787+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=2), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:29:01.370375+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=3), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:29:05.871182+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=4), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:29:10.130193+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=5), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:29:14.377344+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=6), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:29:18.646504+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=7), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:29:23.120296+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=8), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
Running at 2024-09-27T23:29:27.408031+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=9), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('mode_of_interest', str, value='e-bike'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True)]
(emission) root@c594f330cf4b:/usr/src/app/saved-notebooks# 
```

</p>
</details> 

Results:

<img width="1585" alt="Cortez_AnantaImpl" src="https://github.com/user-attachments/assets/c4e51ed2-d909-418e-a34f-b468d9b32165">

