### PR TITLE
Fix the inferred_u80 inferred label bar

### DIFF
--- a/viz_scripts/generic_metrics.ipynb
+++ b/viz_scripts/generic_metrics.ipynb
@@ -388,7 +388,7 @@
     "    text_results = [[\"Unmodified Alt Text\", \"Unmodified HTML\"], [\"Unmodified Alt Text\", \"Unmodified HTML\"], [\"Unmodified Alt Text\", \"Unmodified HTML\"]]\n",
     "    plot_and_text_stacked_bar_chart(expanded_ct_u80, lambda df: df.groupby(\"mode_confirm_w_other\").agg({distance_col: 'count'}).sort_values(by=distance_col, ascending=False), \n",
     "                                    \"Labeled by user\\n\"+labeled_u80_quality_text, ax[0], text_results[0], colors_mode, debug_df, values_to_translations)\n",
-    "    plot_and_text_stacked_bar_chart(expanded_ct_inferred, lambda df: df.groupby(\"mode_confirm_w_other\").agg({distance_col: 'count'}).sort_values(by=distance_col, ascending=False), \n",
+    "    plot_and_text_stacked_bar_chart(expanded_ct_inferred_u80, lambda df: df.groupby(\"mode_confirm_w_other\").agg({distance_col: 'count'}).sort_values(by=distance_col, ascending=False), \n",
     "                                    \"Labeled and Inferred by OpenPATH\\n\"+inferred_u80_quality_text, ax[1], text_results[1], colors_mode, debug_df_inferred, values_to_translations)\n",
     "    plot_and_text_stacked_bar_chart(expanded_ct_sensed_u80, lambda df: df.groupby(\"primary_mode\").agg({distance_col: 'count'}).sort_values(by=distance_col, ascending=False), \n",
     "                                    \"Sensed by OpenPATH\\n\"+sensed_u80_quality_text, ax[2], text_results[2], colors_sensed, debug_df_sensed)\n",


### PR DESCRIPTION
- Use expanded_ct_inferred_u80 instead of expanded_ct_inferred as dataframe for trips under 80% inferred labels

Testing Scenario:

<details><summary>Execution of generic_metrics notebook:</summary>
<p>

```

(emission) root@768bcefa8241:/usr/src/app/saved-notebooks# PYTHONPATH=.. python bin/generate_plots.py generic_metrics.ipynb default
/usr/src/app/saved-notebooks/bin/generate_plots.py:30: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if r.status_code is not 200:
About to download config from https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/configs/cortezebikes.nrel-op.json
Successfully downloaded config with version 1 for Cortez 55+ eBike Program and data collection URL https://cortezebikes-openpath.nrel.gov/api/
label_options is unavailable for the dynamic_config in cortezebikes
Running at 2024-09-29T21:28:04.975100+00:00 with args Namespace(plot_notebook='generic_metrics.ipynb', program='default', date=None) for range (<Arrow [2023-06-01T00:00:00+00:00]>, <Arrow [2024-09-01T00:00:00+00:00]>)
Running at 2024-09-29T21:28:05.014187+00:00 with params [Parameter('year', int), Parameter('month', int), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:28:15.699504+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=6), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:28:23.230393+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=7), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:28:30.583077+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=8), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:28:37.953875+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=9), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:28:45.461316+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=10), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:28:52.838352+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=11), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:29:00.210679+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=12), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:29:07.995342+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=1), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:29:14.585565+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=2), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:29:21.541513+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=3), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:29:26.871463+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=4), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:29:32.413982+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=5), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:29:37.948572+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=6), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:29:43.245589+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=7), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:29:48.510445+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=8), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
Running at 2024-09-29T21:29:53.975169+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=9), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('dynamic_labels', dict, value={}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]
(emission) root@768bcefa8241:/usr/src/app/saved-notebooks# 
```

</p>
</details> 

Results:
<img width="1587" alt="Cortez_u80_Inferred_Labels" src="https://github.com/user-attachments/assets/28639145-f6af-472a-923b-8cd46b0cfe7e">

Note: The sum of value on the right for Labeled and Inferred trips sum up to 3607 trips.

