### PR TITLE
Fix plot title for average miles per transport mode selected's bar chart in generic_metrics_sensed notebook

### DIFF
--- a/viz_scripts/generic_metrics_sensed.ipynb
+++ b/viz_scripts/generic_metrics_sensed.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_title_no_quality=\" Average Miles for each mode with > 3 entries\\n(inferred by OpenPATH from phone sensors)\"\n",
+    "plot_title_no_quality= \"Average \" + label_units + \" for each mode with > 3 entries\\n(inferred by OpenPATH from phone sensors)\"\n",
     "file_name ='average_miles_sensed_mode%s' % file_suffix\n",
     "\n",
     "try:\n",


### PR DESCRIPTION
Update the plot title for average miles per transport mode selected's bar chart in generic_metrics_sensed notebook. 
- Use appropriate metric/imperial unit instead of hardcoded Miles.

Testing Scenario:
Dataset used: `usaid-laos-ev` | use_imperial = false

Ran notebook for generic_metrics_sensed using generate_plots.py
<details><summary>Details of execution: </summary>
<p>

```
(emission) root@c6f239f9e752:/usr/src/app/saved-notebooks# PYTHONPATH=.. python bin/generate_plots.py generic_metrics_sensed.ipynb default
/usr/src/app/saved-notebooks/bin/generate_plots.py:30: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if r.status_code is not 200:
About to download config from https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/configs/usaid-laos-ev.nrel-op.json
Successfully downloaded config with version 1 for USAID-NREL Support for Electric Vehicle Readiness and data collection URL https://USAID-laos-EV-openpath.nrel.gov/api/
Dynamic labels download was successful for nrel-openpath-deploy-configs: usaid-laos-ev
Running at 2024-09-30T16:33:51.511192+00:00 with args Namespace(plot_notebook='generic_metrics_sensed.ipynb', program='default', date=None) for range (<Arrow [2023-05-01T00:00:00+00:00]>, <Arrow [2024-09-01T00:00:00+00:00]>)
Running at 2024-09-30T16:33:51.548641+00:00 with params [Parameter('year', int), Parameter('month', int), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:33:55.534242+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=5), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:33:58.339933+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=6), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:01.167278+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=7), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:04.419353+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=8), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:07.686106+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=9), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:11.117512+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=10), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:14.534747+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=11), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:17.742886+00:00 with params [Parameter('year', int, value=2023), Parameter('month', int, value=12), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:21.078410+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=1), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:24.059108+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=2), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:27.117026+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=3), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:30.110799+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=4), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:33.103254+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=5), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:35.940023+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=6), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:38.929613+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=7), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:41.892982+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=8), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
Running at 2024-09-30T16:34:44.867438+00:00 with params [Parameter('year', int, value=2024), Parameter('month', int, value=9), Parameter('program', str, value='default'), Parameter('study_type', str, value='study'), Parameter('include_test_users', bool, value=True), Parameter('use_imperial', bool, value=False), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('bluetooth_only', bool, value=False)]
(emission) root@c6f239f9e752:/usr/src/app/saved-notebooks#
```

</p>
</details> 

Comparative results:

| Before | After |
|--------|--------|
| <img width="474" alt="Before_Sensed" src="https://github.com/user-attachments/assets/61b2f01f-a546-4388-8a25-034105cc113b"> | <img width="473" alt="After_sensed" src="https://github.com/user-attachments/assets/4bda8f41-2775-4156-9911-2127ea7a2053"> |
