### PR TITLE
Update load_mongodump.sh script to update STUDY_CONFIG in docker-compose.dev.yml

### DIFF
--- a/viz_scripts/docker/load_mongodump.sh
+++ b/viz_scripts/docker/load_mongodump.sh
@@ -53,6 +53,7 @@ echo "Database Name: $DB_NAME"
 DB_HOST="mongodb://db/$DB_NAME"
 sed -i.bak "s|DB_HOST=.*|DB_HOST=$DB_HOST|" "$CONFIG_FILE"
 
+# Update the docker-compose configuration file with the actual STUDY_CONFIG
 STUDY_CONFIG=$(echo "$DB_NAME" | sed -E 's/openpath_prod_(.*)$/\1/' | tr '_' '-')
 sed -i.bak "s|STUDY_CONFIG=.*|STUDY_CONFIG=$STUDY_CONFIG|" "$CONFIG_FILE"
 

--- a/viz_scripts/docker/load_mongodump.sh
+++ b/viz_scripts/docker/load_mongodump.sh
@@ -53,6 +53,9 @@ echo "Database Name: $DB_NAME"
 DB_HOST="mongodb://db/$DB_NAME"
 sed -i.bak "s|DB_HOST=.*|DB_HOST=$DB_HOST|" "$CONFIG_FILE"
 
+STUDY_CONFIG=$(echo "$DB_NAME" | sed -E 's/openpath_prod_(.*)$/\1/' | tr '_' '-')
+sed -i.bak "s|STUDY_CONFIG=.*|STUDY_CONFIG=$STUDY_CONFIG|" "$CONFIG_FILE"
+
 echo "Updated docker-compose file:"
 cat "$CONFIG_FILE"
 


### PR DESCRIPTION
- Update the STUDY_CONFIG in docker-compose.dev.yml config file with the program/study name from the database name of the dataset.
- Expects the database to have a format of openpath_prod_<abc>_<def>_<ghi>. Transforms this database name into "abc-def-ghi", and sets it for the STUDY_CONFIG 

Test execution with the following -
- `openpath-prod-usaid-laos-ev-snapshot-dec-20.tar.gz`

Changes in the `docker-compose.dev.yml` file:
```
ashrest2-41625s:em-public-dashboard ashrest2$ git diff docker-compose.dev.yml
diff --git a/docker-compose.dev.yml b/docker-compose.dev.yml
index 1906101..044b8a4 100644
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,10 +25,10 @@ services:
     depends_on:
       - db
     environment:
-      - DB_HOST=db
+      - DB_HOST=mongodb://db/openpath_prod_usaid_laos_ev
       - WEB_SERVER_HOST=0.0.0.0
       - CRON_MODE=
-      - STUDY_CONFIG=stage-program
+      - STUDY_CONFIG=usaid-laos-ev
     ports:
       # ipynb in numbers
       - "47962:8888"
ashrest2-41625s:em-public-dashboard ashrest2$
```

All the documents were restored successfully
```
2024-10-02T20:19:11.872+0000    [########################]  openpath_prod_usaid_laos_ev.Stage_timeseries  2.42GB/2.42GB  (100.0%)
2024-10-02T20:19:11.872+0000    restoring indexes for collection openpath_prod_usaid_laos_ev.Stage_timeseries from metadata
2024-10-02T20:19:27.034+0000    finished restoring openpath_prod_usaid_laos_ev.Stage_timeseries (3494052 documents, 0 failures)
2024-10-02T20:19:27.034+0000    4441126 document(s) restored successfully. 0 document(s) failed to restore.
Database restore complete.
```

Similarly tested with :
- openpath_prod_ca_ebike_may_29.tar.gz
- openpath_prod_cortezebikes_feb_6.tar.gz
