### PR TITLE
Set 47962 port

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,7 +31,7 @@ services:
       - STUDY_CONFIG=stage-program
     ports:
       # ipynb in numbers
-      - "47962:8888"
+      - "47962:47962"
     networks:
       - emission
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - STUDY_CONFIG=stage-program
     ports:
       # ipynb in numbers
-      - "47962:8888"
+      - "47962:47962"
     networks:
       - emission
     volumes:

--- a/viz_scripts/docker/start_notebook.sh
+++ b/viz_scripts/docker/start_notebook.sh
@@ -30,7 +30,7 @@ cd saved-notebooks
 # tail -f /dev/null
 if [ -z ${CRON_MODE} ] ; then
     echo "Running notebook in docker, change host:port to localhost:47962 in the URL below"
-    PYTHONPATH=/usr/src/app jupyter notebook --no-browser --ip=0.0.0.0 --allow-root
+    PYTHONPATH=/usr/src/app jupyter notebook --no-browser --ip=0.0.0.0 --port=47962 --allow-root
 else
     echo "Running crontab without user interaction, setting python path"
     export PYTHONPATH=/usr/src/app


### PR DESCRIPTION
The documentation reports

> Test the notebook install

> Use the notebook URL from the console but change 8888 to 47962

> http://127.0.0.1:8888/?token=<token>
> becomes

> http://127.0.0.1:47962/?token=<token>


This fix makes the console report the right port from the get-go,
by changing the Jupyter container's starting port.