### PR TITLE
Fix typo for "... mode on land" instead of ". frontend metrics dropdown and update 

### DIFF
--- a/frontend/metrics_program.html
+++ b/frontend/metrics_program.html
@@ -3,7 +3,7 @@
 <option value="ntrips_under80" data-sizex="10" data-sizey="4">Number of trips (under 80th percentile of total trips)</option>
 <option value="ntrips_commute_mode_confirm" data-sizex="10" data-sizey="4">Number of commute trips</option>
 <option value="total_trip_length" data-sizex="10" data-sizey="4">Total trip length (${data.display_config.use_imperial}) covered by mode</option>
-<option value="total_trip_length_land" data-sizex="10" data-sizey="4">Total trip length (${data.display_config.use_imperial}) covered by mode in land</option>
+<option value="total_trip_length_land" data-sizex="10" data-sizey="4">Total trip length (${data.display_config.use_imperial}) covered by mode on land</option>
 <option value="ntrips_purpose" data-sizex="10" data-sizey="4">Number of trips by purpose</option>
 <option value="average_miles_mode_confirm" data-sizex="6" data-sizey="4">Average trip length (${data.display_config.use_imperial})</option>
 <option value="average_miles_sensed_mode" data-sizex="6" data-sizey="4">Average trip length (${data.display_config.use_imperial}) (sensed)</option>

--- a/frontend/metrics_study.html
+++ b/frontend/metrics_study.html
@@ -3,7 +3,7 @@
 <option value="ntrips_under80" data-sizex="10" data-sizey="4">Number of trips (under 80th percentile of total trips)</option>
 <option value="ntrips_commute_mode_confirm" data-sizex="10" data-sizey="4">Number of commute trips</option>
 <option value="total_trip_length" data-sizex="10" data-sizey="4">Total trip length (${data.display_config.use_imperial}) covered by mode</option>
-<option value="total_trip_length_land" data-sizex="10" data-sizey="4">Total trip length (${data.display_config.use_imperial}) covered by mode in land</option>
+<option value="total_trip_length_land" data-sizex="10" data-sizey="4">Total trip length (${data.display_config.use_imperial}) covered by mode on land</option>
 <option value="ntrips_purpose" data-sizex="10" data-sizey="4">Number of trips by purpose</option>
 <option value="average_miles_mode_confirm" data-sizex="6" data-sizey="4">Average trip length (${data.display_config.use_imperial})</option>
 <option value="average_miles_sensed_mode" data-sizex="6" data-sizey="4">Average trip length (${data.display_config.use_imperial}) (sensed)</option>

--- a/viz_scripts/generic_metrics.ipynb
+++ b/viz_scripts/generic_metrics.ipynb
@@ -474,7 +474,7 @@
     "    sensed_land_trips_df = expanded_ct_sensed[expanded_ct_sensed['primary_mode'] != \"AIR_OR_HSR\"]\n",
     "    \n",
     "    sensed_land_quality_text = f\"{len(sensed_land_trips_df)} trips ({round(len(sensed_land_trips_df)/len(expanded_ct_sensed)*100)}% of all trips)\\nfrom {scaffolding.unique_users(sensed_land_trips_df)} {sensed_match.group(3)}\"\n",
-    "    labeled_land_quality_text = f\"{len(labeled_land_trips_df)} trips ({round(len(labeled_land_trips_df)/len(expanded_ct_sensed)*100)}% of all trips)\\nfrom {scaffolding.unique_users(labeled_land_trips_df)} {sensed_match.group(3)}\" if \"Mode_confirm\" in expanded_ct.columns else \"0 labeled trips\"\n",
+    "    labeled_land_quality_text = f\"{len(labeled_land_trips_df)} trips ({round(len(labeled_land_trips_df)/len(expanded_ct)*100)}% of all labeled,\\n{round(len(labeled_land_trips_df)/len(expanded_ct_sensed)*100)}% of all trips)\\nfrom {scaffolding.unique_users(labeled_land_trips_df)} {sensed_match.group(3)}\" if \"Mode_confirm\" in expanded_ct.columns else \"0 labeled trips\"\n",
     "    inferred_land_quality_text = f\"{len(inferred_land_trips_df)} trips ({round(len(inferred_land_trips_df)/len(expanded_ct_inferred)*100)}% of all inferred,\\n{round(len(inferred_land_trips_df)/len(expanded_ct_sensed)*100)}% of all trips)\\nfrom {scaffolding.unique_users(inferred_land_trips_df)} {sensed_match.group(3)}\" if \"Mode_confirm\" in expanded_ct_inferred.columns else \"0 inferred trips\"\n",
     "    \n",
     "    fig, ax = plt.subplots(nrows=3, ncols=1, figsize=(15,3*2), sharex=True)\n",


### PR DESCRIPTION
- Fixed two things
  - Fix typo for "... mode on land" instead of "... mode in land" frontend metrics dropdown and plot name.
  [https://github.com/e-mission/em-public-dashboard/pull/182 changed the plot title to "... mode on land", which has been updated for the frontend metric dropdown and plot name here aeca99fa47f0d1487d46cedc89f4bdce4f0cd108]
  - Update the label description for labeled_land_trips to showcase what % of land trips are in proportion to the overall labeled trips. This aligns with the inferred_land_trips representation - which is in alignment with the 80th percentile trip representation.

Testing Details:

Dataset used : `cortezebikes`

Execution of `generic_metrics notebook` using `generate_plots.py` script:

```
(emission) root@1ae80ce1886d:/usr/src/app/saved-notebooks# PYTHONPATH=.. python bin/generate_plots.py generic_metrics.ipynb default
/usr/src/app/saved-notebooks/bin/generate_plots.py:31: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if r.status_code is not 200:
About to download config from https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/configs/cortezebikes.nrel-op.json
Successfully downloaded config with version 1 for Cortez 55+ eBike Program and data collection URL https://cortezebikes-openpath.nrel.gov/api/
Labels loading was successful for nrel-openpath-deploy-configs: cortezebikes
Running at 2025-01-09T00:49:52.468797+00:00 with args Namespace(plot_notebook='generic_metrics.ipynb', program='default', date=None) for range (<Arrow [2023-06-01T00:00:00+00:00]>, <Arrow [2025-01-01T00:00:00+00:00]>)
Running at 2025-01-09T00:49:52.507269+00:00 with params [Parameter('year', int), Parameter('month', int), Parameter('program', str, value='default'), Parameter('study_type', str, value='program'), Parameter('include_test_users', bool, value=False), Parameter('labels', dict, value={'MODE': [{'value': 'walk', 'base_mode': 'WALKING'}, {'value': 'e-bike', 'base_mode': 'E_BIKE'}, {'value': 'bike', 'base_mode': 'BICYCLING'}, {'value': 'bikeshare', 'base_mode': 'BICYCLING'}, {'value': 'scootershare', 'base_mode': 'E_SCOOTER'}, {'value': 'drove_alone', 'base_mode': 'CAR', 'passengers': 1}, {'value': 'shared_ride', 'base_mode': 'CAR', 'passengers': 2}, {'value': 'hybrid_drove_alone', 'base_mode': 'PHEV_CAR', 'passengers': 1}, {'value': 'hybrid_shared_ride', 'base_mode': 'PHEV_CAR', 'passengers': 2}, {'value': 'e_car_drove_alone', 'base_mode': 'E_CAR', 'passengers': 1}, {'value': 'e_car_shared_ride', 'base_mode': 'E_CAR', 'passengers': 2}, {'value': 'taxi', 'base_mode': 'TAXI'}, {'value': 'bus', 'base_mode': 'BUS'}, {'value': 'train', 'base_mode': 'TRAIN'}, {'value': 'free_shuttle', 'base_mode': 'BUS'}, {'value': 'air', 'base_mode': 'AIR'}, {'value': 'not_a_trip', 'base_mode': 'UNKNOWN'}, {'value': 'other', 'base_mode': 'OTHER'}], 'PURPOSE': [{'value': 'home'}, {'value': 'work'}, {'value': 'at_work'}, {'value': 'school'}, {'value': 'transit_transfer'}, {'value': 'shopping'}, {'value': 'meal'}, {'value': 'pick_drop_person'}, {'value': 'pick_drop_item'}, {'value': 'personal_med'}, {'value': 'access_recreation'}, {'value': 'exercise'}, {'value': 'entertainment'}, {'value': 'religious'}, {'value': 'other'}], 'REPLACED_MODE': [{'value': 'no_travel'}, {'value': 'walk'}, {'value': 'bike'}, {'value': 'bikeshare'}, {'value': 'scootershare'}, {'value': 'drove_alone'}, {'value': 'shared_ride'}, {'value': 'hybrid_drove_alone'}, {'value': 'hybrid_shared_ride'}, {'value': 'e_car_drove_alone'}, {'value': 'e_car_shared_ride'}, {'value': 'taxi'}, {'value': 'bus'}, {'value': 'train'}, {'value': 'free_shuttle'}, {'value': 'other'}], 'translations': {'en': {'walk': 'Walk', 'e-bike': 'E-bike', 'bike': 'Regular Bike', 'bikeshare': 'Bikeshare', 'scootershare': 'Scooter share', 'drove_alone': 'Gas Car Drove Alone', 'shared_ride': 'Gas Car Shared Ride', 'hybrid_drove_alone': 'Hybrid Drove Alone', 'hybrid_shared_ride': 'Hybrid Shared Ride', 'e_car_drove_alone': 'E-Car Drove Alone', 'e_car_shared_ride': 'E-Car Shared Ride', 'taxi': 'Taxi / Uber / Lyft', 'bus': 'Bus', 'train': 'Train', 'free_shuttle': 'Free Shuttle', 'air': 'Air', 'not_a_trip': 'Not a trip', 'no_travel': 'No travel', 'home': 'Home', 'work': 'To Work', 'at_work': 'At Work', 'school': 'School', 'transit_transfer': 'Transit transfer', 'shopping': 'Shopping', 'meal': 'Meal', 'pick_drop_person': 'Pick-up / Drop off Person', 'pick_drop_item': 'Pick-up / Drop off Item', 'personal_med': 'Personal / Medical', 'access_recreation': 'Access Recreation', 'exercise': 'Recreation / Exercise', 'entertainment': 'Entertainment / Social', 'religious': 'Religious', 'other': 'Other'}, 'es': {'walk': 'Caminando', 'e-bike': 'e-bicicleta', 'bike': 'Bicicleta', 'bikeshare': 'Bicicleta compartida', 'scootershare': 'Motoneta compartida', 'drove_alone': 'Coche de Gas, Condujo solo', 'shared_ride': 'Coche de Gas, Condujo con otros', 'hybrid_drove_alone': 'Coche Híbrido, Condujo solo', 'hybrid_shared_ride': 'Coche Híbrido, Condujo con otros', 'e_car_drove_alone': 'e-coche, Condujo solo', 'e_car_shared_ride': 'e-coche, Condujo con otros', 'taxi': 'Taxi / Uber / Lyft', 'bus': 'Autobús', 'train': 'Tren', 'free_shuttle': 'Colectivo gratuito', 'air': 'Avión', 'not_a_trip': 'No es un viaje', 'no_travel': 'No viajar', 'home': 'Casa', 'work': 'Trabajo', 'at_work': 'En el trabajo', 'school': 'Escuela', 'transit_transfer': 'Transbordo', 'shopping': 'Compras', 'meal': 'Comida', 'pick_drop_person': 'Recoger / Entregar Individuo', 'pick_drop_item': 'Recoger / Entregar Objeto', 'personal_med': 'Personal / Médico', 'access_recreation': 'Acceder a Recreación', 'exercise': 'Recreación / Ejercicio', 'entertainment': 'Entretenimiento / Social', 'religious': 'Religioso', 'other': 'Otros'}, 'lo': {'walk': 'ດ້ວຍການຍ່າງ', 'e-bike': 'ວຍລົດຈັກໄຟຟ້າ', 'bike': 'ລົດຖີບ', 'bikeshare': 'ດ້ວຍລົດຖີບທີ່ໃຫ້ເຊົ່າ', 'scootershare': 'ດ້ວຍລົດຈັກສະກູດເຕີ້ໃຫ້ເຊົ່າ ', 'drove_alone': 'ເດີນທາງ ດ້ວຍລົດໃຫ່ຍ ເຊີ່ງເປັນລົດທີ່ຂັບເອງ', 'shared_ride': 'ເດີນທາງດ້ວຍລົດໃຫ່ຍ ຮ່ວມກັບລົດຄົນອຶ່ນ', 'hybrid_drove_alone': 'ລົດປະສົມຂັບຄົນດຽວ', 'hybrid_shared_ride': 'ລົດປະສົມທີ່ໃຊ້ຮ່ວມກັນ', 'e_car_drove_alone': 'ດ້ວຍການຂັບລົດໄຟຟ້າໄປເອງ', 'e_car_shared_ride': 'ດ້ວຍການຈ້າງລົດໄຟຟ້າໄປ', 'taxi': 'ແທັກຊີ', 'bus': 'ລົດເມ', 'train': 'ລົດໄຟ', 'free_shuttle': 'ລົດຮັບສົ່ງຟຣີ', 'air': 'ຍົນ', 'not_a_trip': 'ບໍ່ແມ່ນການເດີນທາງ', 'no_travel': 'ບໍ່ມີການເດີນທາງ', 'home': 'ບ້ານ', 'work': 'ໄປເຮັດວຽກ', 'at_work': 'ຢູ່ບ່ອນເຮັດວຽກ', 'school': 'ໄປໂຮງຮຽນ', 'transit_transfer': 'ການຖ່າຍໂອນການເດີນທາງ', 'shopping': 'ຊອບປິ້ງ', 'meal': 'ອາຫານ', 'pick_drop_person': 'ໄປຮັບ ຫລື ສົນ ຄົນ', 'pick_drop_item': 'ໄປຮັບ ຫລື ສົ່ງສິນຄ້າ', 'personal_med': 'ໄປຫາໝໍ', 'access_recreation': 'ເຂົ້າເຖິງການພັກຜ່ອນ', 'exercise': 'ພັກຜ່ອນ/ອອກກຳລັງກາຍ', 'entertainment': 'ບັນເທີງ/ສັງຄົມ', 'religious': 'ຈຸດປະສົງທາງສາດສະໜາ', 'other': 'ອື່ນໆ'}}}), Parameter('use_imperial', bool, value=True), Parameter('sensed_algo_prefix', str, value='cleaned'), Parameter('survey_info', dict, value={'surveys': {'UserProfileSurvey': {'formPath': 'json/demo-survey-v2.json', 'version': 1, 'compatibleWith': 1, 'dataKey': 'manual/demographic_survey', 'labelTemplate': {'en': 'Answered', 'es': 'Contestada'}}}, 'trip-labels': 'MULTILABEL'})]

```

Result:
| Note | Plot |
|--------|--------|
| Before Change | ![Cor](https://github.com/user-attachments/assets/6e0b52f0-9cc7-45aa-be19-dbd18c86b434) |
| After Change | <img width="529" alt="Cortez)" src="https://github.com/user-attachments/assets/603f66d0-0be4-4ae8-a68c-7147c902164c" /> | 

Changes look good!