### PR TITLE
Quick patch for multiple modes - choose first

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -405,7 +405,12 @@
           // get units
           const dist_units = (data.display_config.use_imperial) ? "miles" : "kilometers";
           console.log("Units for display are", data.display_config.use_imperial, dist_units);
-          mode_studied = data.intro.mode_studied
+          if (Array.isArray(data.intro.mode_studied)) {
+            mode_studied = data.intro.mode_studied[0];
+          }
+          else {
+            mode_studied = data.intro.mode_studied
+          }
           // Load list of plots corresponding to study/program
           dynamic_labels = data.label_options
           survey_list = []

--- a/viz_scripts/bin/generate_plots.py
+++ b/viz_scripts/bin/generate_plots.py
@@ -38,7 +38,10 @@ else:
         f"and data collection URL {dynamic_config['server']['connectUrl'] if 'server' in dynamic_config else 'default'}")
 
 if dynamic_config['intro']['program_or_study'] == 'program':
-    mode_studied = dynamic_config['intro']['mode_studied']
+    if type(dynamic_config['intro']['mode_studied']) == list:
+        mode_studied = dynamic_config['intro']['mode_studied'][0]
+    else:
+        mode_studied = dynamic_config['intro']['mode_studied'] 
 else:
     mode_studied = None
 


### PR DESCRIPTION
On initial read of mode(s) of interest from the config, if the type is list, just choose the first one. This is a quick fix, but should work with no further code change and prevent functionality disruptions to the public dashboard. 

Next pass: allow for multiple modes of interest to be displayed simultaneously! Something like "e-bike or bike" shown where we would normally show "bike" should be fairly easy to implement, it is a matter of expanding the search query and updating the text!

This PR needs testing, still wrangling my tech stack!