### PR TITLE
📊 precompute agg metrics via precompute_metrics.ipynb

### DIFF
--- a/viz_scripts/bin/generate_plots.py
+++ b/viz_scripts/bin/generate_plots.py
@@ -99,6 +99,10 @@ def compute_for_date(month, year):
         year=year,
         month=month,
         program=args.program,
+        dynamic_config=dynamic_config,
+        # TODO: The below params are all derived from dynamic_config.
+        # Since we are now passing the entire dynamic_config, we should be able to
+        # refactor the notebooks to not need these params anymore
         study_type=dynamic_config['intro']['program_or_study'],
         mode_of_interest=mode_studied,
         include_test_users=dynamic_config.get('metrics', {}).get('include_test_users', False),

--- a/viz_scripts/docker/crontab
+++ b/viz_scripts/docker/crontab
@@ -1,3 +1,4 @@
+0 8 * * * python bin/generate_plots.py precompute_metrics.ipynb default >> /var/log/intake.stdinout 2>&1
 0 8 * * * python bin/generate_plots.py generic_metrics.ipynb default >> /var/log/intake.stdinout 2>&1
 0 8 * * * python bin/generate_plots.py generic_metrics_sensed.ipynb default >> /var/log/intake.stdinout 2>&1
 0 8 * * * python bin/generate_plots.py generic_timeseries.ipynb default >> /var/log/intake.stdinout 2>&1

--- a/viz_scripts/precompute_metrics.ipynb
+++ b/viz_scripts/precompute_metrics.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "academic-context",
+   "metadata": {},
+   "source": [
+    "## Precompute metrics for use in other notebooks and for aggregate metrics API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "medium-siemens",
+   "metadata": {},
+   "source": [
+    "These are the input parameters for the notebook. They will be automatically changed when the scripts to generate monthly statistics are run. You can modify them manually to generate multiple plots locally as well.\n",
+    "\n",
+    "Pass in `None` to remove the filters and plot all data. This is not recommended for production settings, but might be useful for reports based on data snapshots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "narrative-hunter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "year = 2023\n",
+    "month = 10\n",
+    "program = \"default\"\n",
+    "dynamic_config = {}\n",
+    "study_type = \"study\"\n",
+    "include_test_users = False\n",
+    "labels = {}\n",
+    "use_imperial = True\n",
+    "sensed_algo_prefix = \"cleaned\"\n",
+    "survey_info = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc49f51a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if year is None or month is None:\n",
+    "    print(\"This notebook only runs when year and month are defined.\")\n",
+    "    exit(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "activated-portugal",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scaffolding\n",
+    "import arrow\n",
+    "import pymongo\n",
+    "\n",
+    "import emission.core.get_database as edb\n",
+    "import emission.storage.timeseries.fmt_time_query as estf\n",
+    "import emission.storage.decorations.analysis_timeseries_queries as esda\n",
+    "import emcommon.metrics.metrics_summaries as emcms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05f48c83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DEFAULT_METRIC_LIST = {\n",
+    "    'footprint': ['mode_confirm'],\n",
+    "    'distance': ['mode_confirm'],\n",
+    "    'duration': ['mode_confirm'],\n",
+    "    'count': ['mode_confirm'],\n",
+    "}\n",
+    "\n",
+    "metric_list = dynamic_config.get('metrics', {}).get('phone_dashboard_ui', {}).get('metric_list', DEFAULT_METRIC_LIST)\n",
+    "\n",
+    "if 'label_options' not in dynamic_config:\n",
+    "    DEFAULT_LABEL_OPTIONS = await emcu.read_json_resource(\"label-options.default.json\")\n",
+    "    dynamic_config['label_options'] = DEFAULT_LABEL_OPTIONS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cf1213d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tq = scaffolding.get_time_query(year, month)\n",
+    "ct = esda.get_entries(esda.CONFIRMED_TRIP_KEY, None, tq)\n",
+    "\n",
+    "metrics = await emcms.generate_summaries(metric_list, ct, dynamic_config)\n",
+    "\n",
+    "agg_metrics_db = edb.get_agg_metrics_db()\n",
+    "op_list = []\n",
+    "skipped_count, upserted_count, modified_count = 0, 0, 0\n",
+    "\n",
+    "for metric_name, days in metrics.items():\n",
+    "    for day in days:\n",
+    "        date_str = day[\"date\"]\n",
+    "        n_users = day[\"nUsers\"]\n",
+    "        data_fields = {\n",
+    "            k: v\n",
+    "            for k, v in day.items()\n",
+    "            if k not in (\"date\", \"nUsers\")\n",
+    "        }\n",
+    "        query = {\"date\": date_str, \"metric\": metric_name}\n",
+    "\n",
+    "        existing = agg_metrics_db.find_one(query)\n",
+    "        needs_update = (\n",
+    "            not existing or\n",
+    "            existing.get(\"nUsers\") != n_users or\n",
+    "            existing.get(\"data\") != data_fields\n",
+    "        )\n",
+    "\n",
+    "        if needs_update:\n",
+    "            doc = {\n",
+    "                \"date\": date_str,\n",
+    "                \"metric\": metric_name,\n",
+    "                \"nUsers\": n_users,\n",
+    "                \"data\": data_fields,\n",
+    "                \"last_updated\": arrow.utcnow().datetime\n",
+    "            }\n",
+    "            op_list.append(pymongo.ReplaceOne(query, doc, upsert=True))\n",
+    "        else:\n",
+    "            skipped_count += 1\n",
+    "\n",
+    "if op_list:\n",
+    "    result = agg_metrics_db.bulk_write(op_list)\n",
+    "    upserted_count = result.upserted_count\n",
+    "    modified_count = result.modified_count\n",
+    "\n",
+    "print(f\"Upserted {upserted_count}, modified {modified_count}, skipped {skipped_count}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.22"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
https://github.com/e-mission/e-mission-docs/issues/1126

This notebook runs before the others and will precompute aggregate metrics for each day and metric, and store them in the DB. This is to reduce the load on the webapp API; before this change, we recomputed aggregate metrics on every request: https://github.com/e-mission/e-mission-server/pull/1060

The rest of the public dashboard does not currently use this structure of day-by-day metrics summaries, so we are still doing extra work from the other notebooks, but we can refactor the public dashboard later to also use the precomputed agg metrics.