### PR TITLE
🐛 run viz scripts month-by-month first and raise from precompute_metrics

### DIFF
--- a/viz_scripts/bin/generate_plots.py
+++ b/viz_scripts/bin/generate_plots.py
@@ -121,9 +121,9 @@ def compute_for_date(month, year):
     # Execute the notebook with the new parameters
     nbclient.execute(new_nb)
 
-# Compute the overall metrics
-compute_for_date(None, None)
-
 # Compute for every month until now
 for month_year in compute_range:
     compute_for_date(month_year.month, month_year.year)
+
+# Compute the overall metrics
+compute_for_date(None, None)

--- a/viz_scripts/precompute_metrics.ipynb
+++ b/viz_scripts/precompute_metrics.ipynb
@@ -40,18 +40,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc49f51a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if year is None or month is None:\n",
-    "    print(\"This notebook only runs when year and month are defined.\")\n",
-    "    exit(0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "activated-portugal",
    "metadata": {},
    "outputs": [],
@@ -64,6 +52,19 @@
     "import emission.storage.timeseries.fmt_time_query as estf\n",
     "import emission.storage.decorations.analysis_timeseries_queries as esda\n",
     "import emcommon.metrics.metrics_summaries as emcms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc49f51a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if year is None or month is None:\n",
+    "    ipython = get_ipython()\n",
+    "    ipython._showtraceback = scaffolding.no_traceback_handler\n",
+    "    raise Exception(\"This notebook only runs when year and month are defined.\")"
    ]
   },
   {


### PR DESCRIPTION
Implement (1) and (3) from https://github.com/e-mission/e-mission-docs/issues/1126#issuecomment-2842427803

> have generate_plots.py run month-by-month BEFORE the overall range (the kernel may still die on overall range)
> find a clean way to exit precompute_metrics.ipynb early (which may require wrapping the later cells in functions and having them execute conditionally)

> in the other notebooks, we just throw an exception if the notebook is not valid.
> https://github.com/e-mission/em-public-dashboard/blob/994b0835465faa4af509a2fa6ec826d4ec4bf475/viz_scripts/survey_metrics.ipynb#L78